### PR TITLE
First pass at allowing cards to be only one way

### DIFF
--- a/asl/numbers_0-30.deck
+++ b/asl/numbers_0-30.deck
@@ -62,10 +62,10 @@ tags: ASL-THAT numbers::11-20
 #https://www.youtube.com/watch?v=hFCXyB6q2nU @1234F-1318F 13
 #https://www.youtube.com/watch?v=hFCXyB6q2nU @1342F-1432F 14
 #https://www.youtube.com/watch?v=hFCXyB6q2nU @1458F-1523F 15
-https://www.youtube.com/watch?v=hFCXyB6q2nU @1572F-1625F 16
-https://www.youtube.com/watch?v=hFCXyB6q2nU @1667F-1720F 17
-https://www.youtube.com/watch?v=hFCXyB6q2nU @1767F-1828F 18
-https://www.youtube.com/watch?v=hFCXyB6q2nU @1865F-1939F 19
+https://www.youtube.com/watch?v=hFCXyB6q2nU @1572F-1625F -> 16
+https://www.youtube.com/watch?v=hFCXyB6q2nU @1667F-1720F -> 17
+https://www.youtube.com/watch?v=hFCXyB6q2nU @1767F-1828F -> 18
+https://www.youtube.com/watch?v=hFCXyB6q2nU @1865F-1939F -> 19
 #https://www.youtube.com/watch?v=hFCXyB6q2nU @1957F-2031F 20
 
 tags: ASL-THAT numbers::21-30

--- a/yanki/anki.py
+++ b/yanki/anki.py
@@ -61,15 +61,27 @@ class VideoField(MediaField):
     return f'<video controls src="{media_filename_html}"></video>'
 
 class Note:
-  def __init__(self, note_id, fields, tags):
+  def __init__(self, note_id, fields, tags, direction='BOTH'):
     self.note_id = note_id
     self.fields = fields
     self.tags = tags
+    self.direction = direction
 
   def add_to_deck(self, deck):
+    fields = self.fields
+    if self.direction == 'BOTH':
+      model = genanki.BASIC_AND_REVERSED_CARD_MODEL
+    elif self.direction == 'LEFT':
+      model = genanki.BASIC_MODEL
+    elif self.direction == 'RIGHT':
+      model = genanki.BASIC_MODEL
+      fields = reversed(self.fields)
+    else:
+      raise ValueError(f"Invalid direction {self.direction}")
+
     deck.add_note(genanki.Note(
-      model=genanki.BASIC_AND_REVERSED_CARD_MODEL,
-      fields=[field.render_anki() for field in self.fields],
+      model=model,
+      fields=[field.render_anki() for field in fields],
       guid=genanki.guid_for(deck.deck_id, self.note_id),
       tags=self.tags,
     ))
@@ -245,8 +257,10 @@ class DeckParser:
     else:
       answer = VideoField(path)
 
+    (direction, question) = self._try_parse_direction(question)
+
     self.deck.add_note(
-      Note(note_id, [Field(question), answer], self.deck.tags))
+      Note(note_id, [Field(question), answer], self.deck.tags, direction))
 
   def _try_parse_clip(self, input, video):
     if not input.startswith("@"):
@@ -268,3 +282,20 @@ class DeckParser:
       return parts[1]
     else:
       return ""
+
+  def _try_parse_direction(self, input):
+    parts = input.split(maxsplit=1)
+
+    if len(parts) >= 2:
+      if parts[0] == '->':
+        direction = 'RIGHT'
+      elif parts[0] == '<-':
+        direction = 'LEFT'
+      elif parts[0] == '<->':
+        direction = 'BOTH'
+      else:
+        return ('BOTH', input)
+
+      return (direction, parts[1])
+    else:
+      return ('BOTH', input)

--- a/yanki/anki.py
+++ b/yanki/anki.py
@@ -12,6 +12,20 @@ os.makedirs(CACHE, exist_ok=True)
 GUID_INPUT_PARAMETERS = ['ss']
 GUID_OUTPUT_PARAMETERS = ['to', 'frames:v']
 
+REVERSED_CARD_MODEL = genanki.Model(
+  1221938101,
+  'Reversed (yanki)',
+  fields=genanki.BASIC_MODEL.fields.copy(),
+  templates=[
+    {
+      'name': 'Card 2',
+      'qfmt': '{{Back}}',
+      'afmt': '{{FrontSide}}\n\n<hr id=answer>\n\n{{Front}}',
+    },
+  ],
+  css=genanki.BASIC_MODEL.css,
+)
+
 def name_to_id(name):
   bytes = hashlib.sha256(name.encode('utf-8')).digest()
   # Apparently deck ID is i64
@@ -68,21 +82,22 @@ class Note:
     self.direction = direction
 
   def add_to_deck(self, deck):
-    fields = self.fields
     if self.direction == 'BOTH':
       model = genanki.BASIC_AND_REVERSED_CARD_MODEL
+      guid = genanki.guid_for(deck.deck_id, self.note_id)
     elif self.direction == 'LEFT':
       model = genanki.BASIC_MODEL
+      guid = genanki.guid_for(deck.deck_id, model, self.note_id)
     elif self.direction == 'RIGHT':
-      model = genanki.BASIC_MODEL
-      fields = reversed(self.fields)
+      model = REVERSED_CARD_MODEL
+      guid = genanki.guid_for(deck.deck_id, model, self.note_id)
     else:
       raise ValueError(f"Invalid direction {self.direction}")
 
     deck.add_note(genanki.Note(
       model=model,
-      fields=[field.render_anki() for field in fields],
-      guid=genanki.guid_for(deck.deck_id, self.note_id),
+      fields=[field.render_anki() for field in self.fields],
+      guid=guid,
       tags=self.tags,
     ))
 


### PR DESCRIPTION
This works, but the front of the card is the video, so it’s hard to identify in the deck browser.

Also, you can’t replace a card of one type with a card of a different type, so likely the note ID should include the direction.

Fixes: #3 Option to produce one way cards