### PR TITLE
Run `ffmpeg` using `asyncio`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ script_launch_mode = "subprocess"
 [tool.ruff]
 line-length = 80
 
+[project]
+requires-python = ">= 3.11"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/video_parameters_test.py
+++ b/tests/video_parameters_test.py
@@ -1,5 +1,5 @@
 import pytest
-from yanki.video import Video
+from yanki.video import Video, VideoOptions
 
 
 def get_video(tmp_path):
@@ -8,7 +8,7 @@ def get_video(tmp_path):
 
     return Video(
         "file://./test-decks/good/media/stopwatch.mp4",
-        cache_path=cache_path,
+        options=VideoOptions(cache_path=cache_path),
     )
 
 

--- a/yanki/anki.py
+++ b/yanki/anki.py
@@ -8,7 +8,7 @@ import os
 
 from yanki.field import Fragment, ImageFragment, VideoFragment, Field
 from yanki.parser import DeckSpec, NoteSpec
-from yanki.video import Video
+from yanki.video import Video, VideoOptions
 
 LOGGER = logging.getLogger(__name__)
 
@@ -86,10 +86,9 @@ def name_to_id(name):
 
 
 class Note:
-    def __init__(self, spec, cache_path, reprocess=False):
+    def __init__(self, spec, video_options: VideoOptions):
         self.spec = spec
-        self.cache_path = cache_path
-        self.reprocess = reprocess
+        self.video_options = video_options
         self.logger = logging.getLogger(
             f"Note[{self.spec.provisional_note_id()}]"
         )
@@ -122,8 +121,7 @@ class Note:
             video = Video(
                 self.spec.video_url(),
                 working_dir=deck_dir,
-                cache_path=self.cache_path,
-                reprocess=self.reprocess,
+                options=self.video_options,
                 logger=self.logger,
             )
             video.audio(self.spec.config.audio)
@@ -295,16 +293,15 @@ class FinalDeck:
 
 class Deck:
     def __init__(
-        self, spec: DeckSpec, cache_path: str, reprocess: bool = False
+        self,
+        spec: DeckSpec,
+        video_options: VideoOptions,
     ):
         self.spec = spec
-        self.cache_path = cache_path
-        self.reprocess = reprocess
+        self.video_options = video_options
         self.notes_by_id = dict()
         for note_spec in spec.note_specs:
-            self.add_note(
-                Note(note_spec, cache_path=cache_path, reprocess=reprocess)
-            )
+            self.add_note(Note(note_spec, video_options=video_options))
 
     async def finalize(self):
         async def finalize_note(collection, note, deck_id):

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -1,8 +1,10 @@
+import asyncio
 import ffmpeg
 import hashlib
 import json
 import logging
 import math
+import multiprocessing
 import os
 from os.path import getmtime
 import shlex
@@ -20,6 +22,9 @@ YT_DLP_OPTIONS = {
 STILL_FORMATS = frozenset(["png", "jpeg", "jpg"])
 FILENAME_ILLEGAL_CHARS = '/"[]'
 
+# FIXME? make this not a global?
+FFMPEG_SEMPHORE = asyncio.Semaphore(multiprocessing.cpu_count())
+
 
 def chars_in(chars, input):
     return [char for char in chars if char in input]
@@ -27,6 +32,15 @@ def chars_in(chars, input):
 
 class BadURL(ValueError):
     pass
+
+
+class FFmpegError(RuntimeError):
+    def __init__(self, command, stderr, exit_code):
+        super(FFmpegError, self).__init__("Error running ffmpeg")
+        self.add_note(f"Command run: {shlex.join(command)}")
+        self.command = command
+        self.stderr = stderr
+        self.exit_code = exit_code
 
 
 # Example YouTube video URLs:
@@ -472,6 +486,13 @@ class Video:
         if not self.reprocess and file_not_empty(output_path):
             return output_path
 
+        return asyncio.run(self.processed_video_async())
+
+    async def processed_video_async(self):
+        output_path = self.processed_video_cache_path()
+        if not self.reprocess and file_not_empty(output_path):
+            return output_path
+
         # Only reprocess once per run.
         self.reprocess = False
 
@@ -520,15 +541,29 @@ class Video:
             *output_streams, output_path, **self.ffmpeg_output_options()
         ).overwrite_output()
 
-        command = shlex.join(stream.compile())
-        self.logger.debug(f"Run {command}")
-        try:
-            stream.run(quiet=True)
-        except ffmpeg.Error as error:
-            error.add_note(f"Ran: {command}")
-            raise
+        await self.run_async(stream)
 
         return output_path
+
+    def run(self, stream):
+        asyncio.run(self.run_async(stream))
+
+    async def run_async(self, stream):
+        command = stream.compile()
+        self.logger.debug(f"Run {shlex.join(command)}")
+
+        async with FFMPEG_SEMPHORE:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            stdout, stderr = await process.communicate()
+
+        if process.returncode:
+            raise FFmpegError(command, stderr, process.returncode)
 
     # Expect { 'v': video?, 'a' : audio? } depending on if -vn and -an are set.
     def _try_apply_slow(self, streams):


### PR DESCRIPTION
This switches to processing videos concurrently (up to the number of CPUs). It improves performance on `asl/numbers-31-100.deck` from 95 seconds to 57 seconds (59% of the time).

Fixes: #11 — Run `ffmpeg` in parallel

### To do

* [x] Test all CLI commands (automating this is issue #13)
* [x] Confirm that common errors are displayed well (I’m sure they’re not).
* [x] Review code with fresh eyes.
* [x] Add option to configure maximum concurrent runs? Currently it pegs my CPU.