### PR TITLE
test-decks_test: Run yanki in a subprocess

### DIFF
--- a/test-decks/errors/bad-crop.deck
+++ b/test-decks/errors/bad-crop.deck
@@ -1,4 +1,4 @@
-# ffmpeg error (see stderr output for detail)
+#ends: Error in ffmpeg. See above.
 title: Test deck::Errors::Bad crop
 crop: 100000:1
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -74,10 +74,9 @@ def test_yanki_to_html(yanki, reference_deck_path):
     result = yanki.run("to-html", reference_deck_path)
     assert result.returncode == 0
     assert result.stderr == ""
-
-    stdout = result.stdout.strip()
-    assert stdout.startswith("<!DOCTYPE html>")
-    assert stdout.endswith("</html>")
+    assert result.stdout.startswith("<!DOCTYPE html>\n")
+    assert result.stdout.endswith("</html>\n")
+    assert result.stdout.count('<div class="note">') == 1
 
 
 def test_yanki_list_notes(yanki, reference_deck_path):

--- a/yanki/cli.py
+++ b/yanki/cli.py
@@ -382,8 +382,7 @@ def generate_index_html(deck_links):
       <body>
         <h1>Decks</h1>
 
-        <ol>
-  """
+        <ol>"""
 
     for file_name, deck in deck_links:
         if deck.title() is None:
@@ -397,8 +396,7 @@ def generate_index_html(deck_links):
         + """
         </ol>
       </body>
-    </html>
-  """
+    </html>"""
     ).lstrip()
 
 
@@ -415,8 +413,7 @@ def htmlize_deck(deck, path_prefix=""):
         <link rel="stylesheet" href="{static_url('general.css')}">
       </head>
       <body>
-        <h1>{h(deck.title())}</h1>
-  """
+        <h1>{h(deck.title())}</h1>"""
 
     for note in deck.notes.values():
         more_html = note.more_field().render_html(path_prefix)
@@ -434,8 +431,7 @@ def htmlize_deck(deck, path_prefix=""):
         output
         + """
       </body>
-    </html>
-  """
+    </html>"""
     ).lstrip()
 
 


### PR DESCRIPTION
This gives us more thorough testing. In particular, it confirms that error messages are reported correctly.

Part of issue #13 — Automate testing of CLI commands