### PR TITLE
`yanki serve-http --open`

### DIFF
--- a/yanki/errors.py
+++ b/yanki/errors.py
@@ -1,0 +1,4 @@
+class ExpectedError(Exception):
+    """An expected error that can be reported without a traceback."""
+
+    pass

--- a/yanki/parser.py
+++ b/yanki/parser.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import functools
 import io
 
+from yanki.errors import ExpectedError
 from yanki.field import Fragment, Field
 
 # Valid variables in note_id format. Used to validate that our code uses the
@@ -21,7 +22,7 @@ NOTE_ID_VARIABLES = frozenset(
 )
 
 
-class DeckSyntaxError(Exception):
+class DeckSyntaxError(ExpectedError):
     def __init__(self, message: str, source_path: str, line_number: int):
         self.message = message
         self.source_path = source_path

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -13,6 +13,8 @@ import shutil
 from urllib.parse import urlparse, parse_qs
 import yt_dlp
 
+from yanki.errors import ExpectedError
+
 LOGGER = logging.getLogger(__name__)
 
 YT_DLP_OPTIONS = {
@@ -28,7 +30,7 @@ def chars_in(chars, input):
     return [char for char in chars if char in input]
 
 
-class BadURL(ValueError):
+class BadURL(ExpectedError):
     pass
 
 


### PR DESCRIPTION
- **`ExpectedError` base class for when a traceback isn’t desired.**
- **`serve-http --open` to open the site in a web browser.**
