### PR TITLE
Don’t use colons in cache paths

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -129,7 +129,7 @@ def test_yanki_list_final_notes(yanki, reference_deck_path, cache_path):
     """Check that list-notes can list notes after being processed."""
     result = yanki.run("list-notes", "-f", "{media_paths}", reference_deck_path)
     assert result.returncode == 0
-    assert result.stdout.startswith(f"{cache_path}/processed_file:||")
+    assert result.stdout.startswith(f"{cache_path}/processed_file\\=||")
     assert result.stderr == ""
 
 
@@ -140,7 +140,7 @@ def test_yanki_open_videos(yanki, reference_deck_path, cache_path):
         "open-videos", f"file://{reference_deck_path.parent}/first.png"
     )
     assert result.returncode == 0
-    assert result.stdout.startswith(f"{cache_path}/processed_file:||")
+    assert result.stdout.startswith(f"{cache_path}/processed_file\\=||")
     assert result.stderr == ""
 
 
@@ -152,5 +152,5 @@ def test_yanki_open_videos_from_file(yanki, reference_deck_path, cache_path):
         stdin=io.StringIO(f"file://{reference_deck_path.parent}/first.png\n"),
     )
     assert result.returncode == 0
-    assert result.stdout.startswith(f"{cache_path}/processed_file:||")
+    assert result.stdout.startswith(f"{cache_path}/processed_file\\=||")
     assert result.stderr == ""

--- a/tests/url_to_id_test.py
+++ b/tests/url_to_id_test.py
@@ -152,12 +152,12 @@ https://youtu.be/lalOy8Mbfdc?si=B_RZg_I-lLaa7UU-
 def test_youtube_urls():
     for url in YOUTUBE_URLS.split():
         assert (
-            url_to_id(url) == "youtube:" + YOUTUBE_ID
+            url_to_id(url) == "youtube=" + YOUTUBE_ID
         ), f"id {YOUTUBE_ID} not in {url!r}"
 
 
 def test_other_urls():
     assert (
         url_to_id("https://example.com/video.mp4")
-        == "https:||example.com|video.mp4"
+        == r"https\=||example.com|video.mp4"
     )

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -23,7 +23,7 @@ YT_DLP_OPTIONS = {
 }
 
 STILL_FORMATS = frozenset(["png", "jpeg", "jpg"])
-FILENAME_ILLEGAL_CHARS = '/"[]'
+FILENAME_ILLEGAL_CHARS = '/"[]:'
 
 
 def chars_in(chars, input):
@@ -95,9 +95,9 @@ def url_to_id(url_str):
     try:
         domain = "." + url.netloc.lower()
         if domain.endswith(".youtube.com"):
-            return "youtube:" + youtube_url_to_id(url_str, url, query)
+            return "youtube=" + youtube_url_to_id(url_str, url, query)
         elif domain.endswith(".youtu.be"):
-            return "youtube:" + youtu_be_url_to_id(url_str, url, query)
+            return "youtube=" + youtu_be_url_to_id(url_str, url, query)
     except BadURL:
         # Try to load the URL with yt_dlp and see what happens.
         pass
@@ -109,6 +109,7 @@ def url_to_id(url_str):
         .replace('"', r"\'")
         .replace("[", r"\(")
         .replace("]", r"\)")
+        .replace(":", r"\=")
         .replace("/", "|")
     )
 


### PR DESCRIPTION
Anki can support colons even in `[sound:my:file.mp4]`, but why tempt fate?