### PR TITLE
Create `CACHEDIR.TAG` file in cache

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -132,6 +132,10 @@ def test_yanki_list_final_notes(yanki, reference_deck_path, cache_path):
     assert result.stdout.startswith(f"{cache_path}/processed_file\\=||")
     assert result.stderr == ""
 
+    # Might as well check CACHEDIR.TAG too. See https://bford.info/cachedir/
+    contents = (cache_path / "CACHEDIR.TAG").read_bytes()
+    assert contents[:43] == b"Signature: 8a477f597d28d172789f06886806bc55"
+
 
 # Fake `open` doesn’t work without subprocess.
 @pytest.mark.script_launch_mode("subprocess")

--- a/yanki/cli.py
+++ b/yanki/cli.py
@@ -105,13 +105,13 @@ def cli(ctx, verbose, cache, reprocess, concurrency):
     if concurrency < 1:
         raise click.UsageError("--concurrency must be >= 1.")
 
+    ensure_cache(cache)
+
     ctx.obj = VideoOptions(
         cache_path=cache,
         reprocess=reprocess,
         semaphore=asyncio.Semaphore(concurrency),
     )
-
-    cache.mkdir(parents=True, exist_ok=True)
 
     # Configure logging
     if verbose > 2:
@@ -352,6 +352,24 @@ def open_videos_from_file(options, files):
             except yt_dlp.utils.DownloadError:
                 # yt_dlp prints the error itself.
                 pass
+
+
+CACHEDIR_TAG_CONTENT = """Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag created by yanki.
+# For information about cache directory tags, see:
+#	https://bford.info/cachedir/
+#
+# For information about yanki, see:
+#   https://github.com/danielparks/yanki
+"""
+
+
+def ensure_cache(cache_path: Path):
+    """Make sure cache is set up."""
+    cache_path.mkdir(parents=True, exist_ok=True)
+
+    tag_path = cache_path / "CACHEDIR.TAG"
+    tag_path.write_text(CACHEDIR_TAG_CONTENT, encoding="ascii")
 
 
 def find_errors(group: ExceptionGroup):


### PR DESCRIPTION
This will prevent many backup programs from backing up the directory. I haven’t made this optional; I can do that in a future update if it’s actually desired.

Fixes: #35
