### PR TITLE
`yanki.utils` and `atomic_open()`

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -25,8 +25,7 @@ def reference_deck_path(tmp_path_factory):
     decks = tmp_path_factory.mktemp("decks")
     shutil.copy("test-decks/good/media/first.png", decks / "first.png")
     path = decks / "reference.deck"
-    with open(path, "w") as file:
-        file.write(REFERENCE_DECK)
+    path.write_text(REFERENCE_DECK, encoding="utf_8")
     return path
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,7 @@ def bin_path(tmp_path_factory):
 
     for command in ["open", "xdg-open"]:
         open_path = path / command
-        with open(open_path, "w") as file:
-            file.write("#!/bin/sh\necho $*\n")
+        open_path.write_bytes(b"#!/bin/sh\necho $*\n")
         open_path.chmod(0o755)
 
     return path

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,0 +1,35 @@
+import pytest
+from yanki.utils import atomic_open
+
+
+def test_atomic_open(tmp_path):
+    path = tmp_path / "prefix.suffix"
+
+    with atomic_open(path) as file:
+        file.write("First write\n")
+    assert path.read_text() == "First write\n"
+    assert [path.name for path in tmp_path.iterdir()] == ["prefix.suffix"]
+
+    with atomic_open(path) as file:
+        file.write("Second write\n")
+    assert path.read_text() == "Second write\n"
+    assert [path.name for path in tmp_path.iterdir()] == ["prefix.suffix"]
+
+
+def test_atomic_open_error(tmp_path):
+    path = tmp_path / "prefix.suffix"
+
+    with atomic_open(path) as file:
+        file.write("First write\n")
+    assert path.read_text() == "First write\n"
+    assert [path.name for path in tmp_path.iterdir()] == ["prefix.suffix"]
+
+    with pytest.raises(RuntimeError) as error_info:
+        with atomic_open(path) as file:
+            file.write("Second write\n")
+            file.close()
+            raise RuntimeError("boo")
+    assert error_info.match("boo")
+
+    assert path.read_text() == "First write\n"
+    assert [path.name for path in tmp_path.iterdir()] == ["prefix.suffix"]

--- a/yanki/cli.py
+++ b/yanki/cli.py
@@ -266,8 +266,7 @@ def serve_http(options, decks, do_open, bind, run_seconds):
     # FIXME serve html from memory so that you can run multiple copies of
     # this tool at once.
     index_path = options.cache_path / "index.html"
-    with index_path.open("w", encoding="utf_8") as file:
-        file.write(generate_index_html(deck_links))
+    index_path.write_text(generate_index_html(deck_links), encoding="utf_8")
 
     # FIXME it would be great to just serve this directory as /static without
     # needing the symlink.

--- a/yanki/utils.py
+++ b/yanki/utils.py
@@ -1,0 +1,61 @@
+import os
+import tempfile
+from urllib.parse import urlparse
+import contextlib
+
+
+def file_url_to_path(url):
+    parts = urlparse(url)
+    if parts.scheme.lower() != "file":
+        return None
+
+    # urlparse doesn’t handle file: very well:
+    #
+    #   >>> urlparse('file://./media/first.png')
+    #   ParseResult(scheme='file', netloc='.', path='/media/first.png', ...)
+    return parts.netloc + parts.path
+
+
+def file_not_empty(path):
+    """Checks that the path is a file and is non-empty."""
+    return os.path.exists(path) and os.stat(path).st_size > 0
+
+
+@contextlib.contextmanager
+def atomic_open(path, encoding="utf_8"):
+    """
+    Open a file for writing and save it atomically.
+
+    This creates a temporary file in the same directory, writes to it, then
+    replaces the target file atomically even if it already exists.
+    """
+
+    if encoding is None:
+        mode = "wb"
+    else:
+        mode = "w"
+
+    directory = os.path.dirname(path)
+    (prefix, suffix) = os.path.splitext(os.path.basename(path))
+    with tempfile.NamedTemporaryFile(
+        mode=mode,
+        encoding=encoding,
+        dir=directory,
+        prefix=f"working_{prefix}",
+        suffix=suffix,
+        delete=True,
+        delete_on_close=False,
+    ) as temp_file:
+        yield temp_file
+        os.rename(temp_file.name, path)
+        # Nothing for NamedTemporaryFile to delete.
+
+
+def get_key_path(data, path: list[any]):
+    for key in path:
+        data = data[key]
+    return data
+
+
+def chars_in(chars, input):
+    return [char for char in chars if char in input]


### PR DESCRIPTION
This moves some utility functions out of `yanki.video`, and creates a new `atomic_open()` function that generates a temporary file, then moves it into place atomically.

This ensures that we don’t end up with a corrupt file, e.g. of metadata, if it is interupted in the middle of writing the file.

Fixes: #33 — Create cache files atomically