### PR TITLE
Move config directive handling into `NoteConfig`

### DIFF
--- a/asl/extra.deck
+++ b/asl/extra.deck
@@ -93,11 +93,11 @@ https://www.youtube.com/watch?v=ApOIQTLewCw [one-person]-TELL-[other-person]
   trim: 16F-72F
 
 https://www.youtube.com/watch?v=l3pElzy2Png BUT / however / different
-  more+ rst:`BUT <https://lifeprint.com/asl101/pages-signs/b/but.htm>`_
+  more: +rst:`BUT <https://lifeprint.com/asl101/pages-signs/b/but.htm>`_
 https://www.youtube.com/watch?v=EunD6JXshgY DIFFERENT
-  more+ rst:`DIFFERENT <https://lifeprint.com/asl101/pages-signs/d/different.htm>`_
+  more: +rst:`DIFFERENT <https://lifeprint.com/asl101/pages-signs/d/different.htm>`_
 https://www.youtube.com/watch?v=OwtSP1QozuE ALSO / SAME (index finger version)
-  more+ rst:`SAME <https://lifeprint.com/asl101/pages-signs/s/same.htm>`_
+  more: +rst:`SAME <https://lifeprint.com/asl101/pages-signs/s/same.htm>`_
 
 # Related to lesson 7 — food
 https://www.youtube.com/watch?v=mZVixrzz_MM MUSHROOM

--- a/asl/lesson-01.deck
+++ b/asl/lesson-01.deck
@@ -102,7 +102,7 @@ https://www.youtube.com/watch?v=J8cuP-YSZIA DEAF-APPLAUSE / yay
 # No video for just plain KNOW
 https://www.youtube.com/watch?v=Ht2B0VzHFwQ FAMILIAR / KNOWLEDGE
   trim: 9F-72F
-  more+ KNOW would be a single movement.
+  more: +KNOW would be a single movement.
 https://www.youtube.com/watch?v=MBzzJk_5WwY -> KNOW (casual version)
   trim: 16F-52F
 https://www.youtube.com/watch?v=UF79ZPZz1hA don’t-KNOW

--- a/asl/lesson-02.deck
+++ b/asl/lesson-02.deck
@@ -75,14 +75,14 @@ https://www.youtube.com/watch?v=NRbLBTghqNk OUR
 
 https://www.youtube.com/watch?v=QVPcK3bcFo0 SINGLE / SOMETHING / SOMEONE / ONLY
   trim: 12F-75F
-  more+ rst:`SINGLE <https://www.lifeprint.com/asl101/pages-signs/s/single.htm>`_
+  more: +rst:`SINGLE <https://www.lifeprint.com/asl101/pages-signs/s/single.htm>`_
   tags: +first_100_signs
 https://www.youtube.com/watch?v=2ikniviFkgo JUST / ONLY / merely
   trim: 17F-81F
-  more+ rst:`JUST <https://www.lifeprint.com/asl101/pages-signs/j/just.htm>`_
+  more: +rst:`JUST <https://www.lifeprint.com/asl101/pages-signs/j/just.htm>`_
 https://www.youtube.com/watch?v=t0WcqBpEG_0 SINGLE (not married, chin version)
   trim: 15F-66F
-  more+ rst:`SINGLE <https://www.lifeprint.com/asl101/pages-signs/s/single.htm>`_
+  more: +rst:`SINGLE <https://www.lifeprint.com/asl101/pages-signs/s/single.htm>`_
 
 https://www.youtube.com/watch?v=0z2_gcB5OJ8 SISTER
   trim: 15F-96F

--- a/asl/lesson-03-phrases.deck
+++ b/asl/lesson-03-phrases.deck
@@ -15,7 +15,7 @@ https://www.youtube.com/watch?v=uKAKaQG5FTI CITY YOU LIVE?
 https://www.youtube.com/watch?v=OrJZaf91g10 YOUR HOUSE BIG?
 https://www.youtube.com/watch?v=D2uRaydjqmE CHILDREN, YOU HOW-MANY?
 https://www.youtube.com/watch?v=hNZhHC6NcxI YOUR HOUSE BATHROOM HOW-MANY?
-  more+ html:<h3>How many bathrooms are there in your house?</h3>
+  more: +html:<h3>How many bathrooms are there in your house?</h3>
 # YOU WORK WHERE? already in lesson 2 phrases
 https://www.youtube.com/watch?v=A__YN6x4IFk YOU LIKE YOUR WORK?
 https://www.youtube.com/watch?v=9ZZE0cZwCmg YOU THINK I SIGN GOOD?

--- a/asl/lesson-05.deck
+++ b/asl/lesson-05.deck
@@ -48,20 +48,20 @@ https://www.youtube.com/watch?v=lnDgTFrQLwU OUTSIDE (place)
 
 https://www.youtube.com/watch?v=g4AwGIjxn7k WITH
   trim: 11F-76F
-  more+ rst:`WITH <https://www.lifeprint.com/asl101/pages-signs/w/with.htm>`_
+  more: +rst:`WITH <https://www.lifeprint.com/asl101/pages-signs/w/with.htm>`_
   tags: +first_100_signs
 https://www.youtube.com/watch?v=kq2iGRiNAvk
   WITH-long-term / go-steady / monogamous
   trim: 10F-82F
-  more+ rst:`WITH <https://www.lifeprint.com/asl101/pages-signs/w/with.htm>`_
+  more: +rst:`WITH <https://www.lifeprint.com/asl101/pages-signs/w/with.htm>`_
   tags: +extra
 https://www.youtube.com/watch?v=fAydfnFBDDw GO-WITH / ACCOMPANY
   trim: 13F-80F
-  more+ rst:`WITH <https://www.lifeprint.com/asl101/pages-signs/w/with.htm>`_
+  more: +rst:`WITH <https://www.lifeprint.com/asl101/pages-signs/w/with.htm>`_
   tags: +extra
 https://www.youtube.com/watch?v=H8frIh9Lb_A all-TOGETHER / solidarity
   trim: 14F-88F
-  more+ rst:`WITH <https://www.lifeprint.com/asl101/pages-signs/w/with.htm>`_
+  more: +rst:`WITH <https://www.lifeprint.com/asl101/pages-signs/w/with.htm>`_
   tags: +extra
 
 tags: +extra

--- a/asl/lesson-07-phrases.deck
+++ b/asl/lesson-07-phrases.deck
@@ -31,13 +31,13 @@ https://www.youtube.com/watch?v=f8Cc7T6-BO8
 
   (How many cups of water do you drink daily?)
 
-  more+ In this version you can see how I'm taking time to emphasize “CUPS.” This version helps clarify that I want to know specifically the number of cups that are being drank on a daily basis. Plus I put the “HOW-MANY” and the end which fits in nicely with traditional ASL grammar.
+  more: +In this version you can see how I'm taking time to emphasize “CUPS.” This version helps clarify that I want to know specifically the number of cups that are being drank on a daily basis. Plus I put the “HOW-MANY” and the end which fits in nicely with traditional ASL grammar.
 https://www.youtube.com/watch?v=kD2CrJ_RQAU
   WATER YOU DRINK EVERYDAY HOW-MANY CUPS?
 
   (How many cups of water do you drink daily?)
 
-  more+ There are some people that will insist you should do the sign “EVERYDAY” as the first sign in this sentence. Honestly, I don't think “time/tense” is instrumental to this sentence (conjugation of verbs and such). For simplicity sake I'm just going to show you this general version.
+  more: +There are some people that will insist you should do the sign “EVERYDAY” as the first sign in this sentence. Honestly, I don't think “time/tense” is instrumental to this sentence (conjugation of verbs and such). For simplicity sake I'm just going to show you this general version.
 https://www.youtube.com/watch?v=oKIZ8Mt7iAw
   YOUR FAVORITE FOOD WHAT?
 

--- a/asl/lesson-08.deck
+++ b/asl/lesson-08.deck
@@ -6,7 +6,7 @@ audio: strip
 note_id: Lifeprint ASL {url} {clip}
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`BACKPACK <https://www.lifeprint.com/asl101/pages-signs/b/backpack.htm>`_
+more: +rst:`BACKPACK <https://www.lifeprint.com/asl101/pages-signs/b/backpack.htm>`_
 # FIXME Need a better way to do this — show all videos at once when they’re the
 # answer, or maybe in sequence? That would be 5 cards instead of 8.
 https://www.youtube.com/watch?v=St5PWSrZpOY BACKPACK-[A-hand version]
@@ -19,7 +19,7 @@ https://www.youtube.com/watch?v=Le7g5M_zIJQ -> BACKPACK-[modified-C-hand version
   trim: 11F-56F
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`BASKET <https://www.lifeprint.com/asl101/pages-signs/b/basket.htm>`_
+more: +rst:`BASKET <https://www.lifeprint.com/asl101/pages-signs/b/basket.htm>`_
 https://www.youtube.com/watch?v=YvegBgfEEO4
   BASKET (typical) / BOWL / tub / basin / sink
   trim: 17F-67F
@@ -30,28 +30,28 @@ https://www.youtube.com/watch?v=I6k9JY_aPTM BASKET-with-handle
   tags: +extra
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`BATTERY <https://www.lifeprint.com/asl101/pages-signs/b/battery.htm>`_
+more: +rst:`BATTERY <https://www.lifeprint.com/asl101/pages-signs/b/battery.htm>`_
 https://www.youtube.com/watch?v=MYZPHcuXGGs BATTERY / ELECTRIC
   trim: 11F-71F
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`BELT <https://www.lifeprint.com/asl101/pages-signs/b/belt.htm>`_
+more: +rst:`BELT <https://www.lifeprint.com/asl101/pages-signs/b/belt.htm>`_
 https://www.youtube.com/watch?v=RNxKCnCTRT0 BELT
   trim: 8F-72F
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`CHANGE <https://www.lifeprint.com/asl101/pages-signs/c/change.htm>`_
+more: +rst:`CHANGE <https://www.lifeprint.com/asl101/pages-signs/c/change.htm>`_
 https://www.youtube.com/watch?v=lT0E7jGHIKY CHANGE-[verb]
   trim: 8F-72F
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`COAT <https://www.lifeprint.com/asl101/pages-signs/c/coat.htm>`_
+more: +rst:`COAT <https://www.lifeprint.com/asl101/pages-signs/c/coat.htm>`_
 https://www.youtube.com/watch?v=HWMc-nzJ2MQ COAT / JACKET
   trim: 10F-65F
   tags: +first_100_signs
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`DIRTY <https://www.lifeprint.com/asl101/pages-signs/d/dirty.htm>`_
+more: +rst:`DIRTY <https://www.lifeprint.com/asl101/pages-signs/d/dirty.htm>`_
 https://www.youtube.com/watch?v=K3BygEHQ-Ps DIRTY
   trim: 7F-58F
 https://www.youtube.com/watch?v=O1kESRrCxXs
@@ -59,7 +59,7 @@ https://www.youtube.com/watch?v=O1kESRrCxXs
   trim: 13F-80F
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`GLASSES <https://www.lifeprint.com/asl101/pages-signs/g/glasses.htm>`_
+more: +rst:`GLASSES <https://www.lifeprint.com/asl101/pages-signs/g/glasses.htm>`_
 https://www.youtube.com/watch?v=Z7mTRgU_Xqs
   GLASSES / THOMAS GALLAUDET / GALLAUDET UNIVERSITY / Moses
   trim: 10F-54F
@@ -67,17 +67,17 @@ https://www.youtube.com/watch?v=s52iaD1mxXU GOGGLES / GLASSES
   trim: 11F-65F
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`HEARING-AID <https://www.lifeprint.com/asl101/pages-signs/h/hearing-aid.htm>`_
+more: +rst:`HEARING-AID <https://www.lifeprint.com/asl101/pages-signs/h/hearing-aid.htm>`_
 https://www.youtube.com/watch?v=U3LYX2NPHzc HEARING-AID
   trim: 13F-69F
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`WASHING-MACHINE <https://www.lifeprint.com/asl101/pages-signs/w/washingmachine.htm>`_
+more: +rst:`WASHING-MACHINE <https://www.lifeprint.com/asl101/pages-signs/w/washingmachine.htm>`_
 https://www.youtube.com/watch?v=m8FIqLT7DcI LAUNDRY / WASHING-MACHINE
   trim: 8F-58F
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`OFF <https://www.lifeprint.com/asl101/pages-signs/o/off.htm>`_
+more: +rst:`OFF <https://www.lifeprint.com/asl101/pages-signs/o/off.htm>`_
 https://www.youtube.com/watch?v=0NT8n6PZ4pI #OFF
   trim: 13F-46F
 https://www.youtube.com/watch?v=0aux6b4MDSQ POWER-OFF
@@ -88,20 +88,20 @@ https://www.youtube.com/watch?v=nh_PLvAkWpU LIGHTS-OFF
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
 https://www.youtube.com/watch?v=vl1LG51Wd1c ->
   OFF-[removed-or-separated-from]
-  more+ rst:Be sure to read `OFF <https://www.lifeprint.com/asl101/pages-signs/o/off.htm>`_
+  more: +rst:Be sure to read `OFF <https://www.lifeprint.com/asl101/pages-signs/o/off.htm>`_
   trim: 21F-75F
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
 https://www.youtube.com/watch?v=e8hiRj3xDiw
   ON / onto
-  more+ rst:Be sure to read `ON <https://www.lifeprint.com/asl101/pages-signs/o/on.htm>`_
+  more: +rst:Be sure to read `ON <https://www.lifeprint.com/asl101/pages-signs/o/on.htm>`_
   trim: 15F-66F
-more+ rst:`ON <https://www.lifeprint.com/asl101/pages-signs/o/on.htm>`_ and `LIGHTS <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
+more: +rst:`ON <https://www.lifeprint.com/asl101/pages-signs/o/on.htm>`_ and `LIGHTS <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
 https://www.youtube.com/watch?v=w0Sl6ta4Obo LIGHTS-ON / LIGHTS
   trim: 35F-115F
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`PANTS <https://www.lifeprint.com/asl101/pages-signs/p/pants.htm>`_
+more: +rst:`PANTS <https://www.lifeprint.com/asl101/pages-signs/p/pants.htm>`_
 https://www.youtube.com/watch?v=-V0Dkeyno2s PANTS (pull up version)
   trim: 10F-61F
   tags: +first_100_signs
@@ -113,12 +113,12 @@ https://www.youtube.com/watch?v=K-791JkOMv0 pants-POCKET
 # https://www.youtube.com/watch?v=53ir6-NIKl4 pants-POCKET (version 2)
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`FIND <https://www.lifeprint.com/asl101/pages-signs/f/find.htm>`_
+more: +rst:`FIND <https://www.lifeprint.com/asl101/pages-signs/f/find.htm>`_
 https://www.youtube.com/watch?v=2O5wVw-rlIs FIND / pick-up / discover
   trim: 12F-87F
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`SHIRT <https://www.lifeprint.com/asl101/pages-signs/s/shirt.htm>`_
+more: +rst:`SHIRT <https://www.lifeprint.com/asl101/pages-signs/s/shirt.htm>`_
 https://www.youtube.com/watch?v=BLqzpaKkkk4
   SHIRT / volunteer / apply / candidate
   trim: 5F-84F
@@ -164,7 +164,7 @@ https://www.youtube.com/watch?v=DGfm9blIRJs LOGO-ON-SHIRT-[CL: bent-L]
 tags: -extra
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`SHOES <https://www.lifeprint.com/asl101/pages-signs/s/shoes.htm>`_
+more: +rst:`SHOES <https://www.lifeprint.com/asl101/pages-signs/s/shoes.htm>`_
 https://www.youtube.com/watch?v=Yoi_OLX0IEs SHOES
   trim: 12F-82F
   tags: +first_100_signs
@@ -184,13 +184,13 @@ https://www.youtube.com/watch?v=KF7M_6Lk66M
 tags: -extra
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`SOCKS <https://www.lifeprint.com/asl101/pages-signs/s/socks.htm>`_
+more: +rst:`SOCKS <https://www.lifeprint.com/asl101/pages-signs/s/socks.htm>`_
 https://www.youtube.com/watch?v=arMsuswd_AM SOCKS
   trim: 11F-58F
   tags: +first_100_signs
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`UNDERWEAR <https://www.lifeprint.com/asl101/pages-signs/u/underwear.htm>`_
+more: +rst:`UNDERWEAR <https://www.lifeprint.com/asl101/pages-signs/u/underwear.htm>`_
 https://www.youtube.com/watch?v=yKAFC9iyxas UNDERWEAR
   trim: 7F-
   tags: +first_100_signs
@@ -207,12 +207,12 @@ https://www.youtube.com/watch?v=WolgARwE0Hg bikini / SWIM BRA UNDERWEAR
 tags: -extra
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`WHICH <https://www.lifeprint.com/asl101/pages-signs/w/which.htm>`_
+more: +rst:`WHICH <https://www.lifeprint.com/asl101/pages-signs/w/which.htm>`_
 https://www.youtube.com/watch?v=DlMZXBngGKM WHICH
   trim: 8F-52F
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`ZIP <https://www.lifeprint.com/asl101/pages-signs/z/zip.htm>`_
+more: +rst:`ZIP <https://www.lifeprint.com/asl101/pages-signs/z/zip.htm>`_
 https://www.youtube.com/watch?v=8wuLrFkO-SU ZIPPER / ZIP-up
   trim: 11F-64F
 https://www.youtube.com/watch?v=m9fxgSPo0s0 Z-I-P / zip code
@@ -222,7 +222,7 @@ https://www.youtube.com/watch?v=XOLT0_VXgpY ZIP-up-jacket
   tags: +extra
 
 more: rst:From `Lifeprint <https://www.lifeprint.com/>`_ ASLU `lesson 8 <https://www.lifeprint.com/asl101/lessons/lesson08.htm>`_
-more+ rst:`CLOTHES <https://www.lifeprint.com/asl101/pages-signs/c/clothes.htm>`_
+more: +rst:`CLOTHES <https://www.lifeprint.com/asl101/pages-signs/c/clothes.htm>`_
 https://www.youtube.com/watch?v=15czV0-SagI CLOTHES (two handed)
   trim: 11F-77F
 https://www.youtube.com/watch?v=kDyFU6UL3qk DRESS / GOWN
@@ -265,7 +265,7 @@ tags: +extra
 # HARD-OF-HEARING is in lesson 13, but I want to test moving decks.
 https://www.youtube.com/watch?v=gz_R3F29Je0 HARD-OF-HEARING
   trim: 11F-72F
-  more+ rst:`HARD-OF-HEARING <https://www.lifeprint.com/asl101/pages-signs/h/hard-of-hearing.htm>`_
+  more: +rst:`HARD-OF-HEARING <https://www.lifeprint.com/asl101/pages-signs/h/hard-of-hearing.htm>`_
 https://www.youtube.com/watch?v=Yx5t_1SvVWs COMFORTABLE
   trim: 9F-73F
-  more+ rst:`COMFORTABLE <https://www.lifeprint.com/asl101/pages-signs/c/comfortable.htm>`_
+  more: +rst:`COMFORTABLE <https://www.lifeprint.com/asl101/pages-signs/c/comfortable.htm>`_

--- a/asl/lesson-09-phrases.deck
+++ b/asl/lesson-09-phrases.deck
@@ -7,45 +7,45 @@ audio: strip
 note_id: Lifeprint ASL {url} {clip}
 
 https://www.youtube.com/watch?v=Mg3fZ7eWltE YOU LIVE BASEMENT APT?
-  more+ html:<h3>Do you live in a basement apartment?</h3>
+  more: +html:<h3>Do you live in a basement apartment?</h3>
 https://www.youtube.com/watch?v=bgxDQeKmqfw BATH, SHOWER, YOU PREFER WHICH?
-  more+ html:<h3>Which do you prefer, taking a bath or taking a shower?</h3>
+  more: +html:<h3>Which do you prefer, taking a bath or taking a shower?</h3>
 https://www.youtube.com/watch?v=BA3HI1YA5YI YOUR BATHROOM HAVE T-U-B?
-  more+ html:<h3>Does your bathroom have a tub?</h3>
+  more: +html:<h3>Does your bathroom have a tub?</h3>
 https://www.youtube.com/watch?v=lHKwVJ0S4Ec YOU TOGETHER-steady SOMEONE?
-  more+ html:<h3>Are you going steady with someone?</h3>
+  more: +html:<h3>Are you going steady with someone?</h3>
 https://www.youtube.com/watch?v=Yw6CGi9riWw YOUR COUCH, COLOR?
-  more+ html:<h3>What color is your couch?</h3>
+  more: +html:<h3>What color is your couch?</h3>
 https://www.youtube.com/watch?v=vHwnwtCaFL0 GARAGE HAVE?
-  more+ html:<h3>Do you have a garage?</h3>
+  more: +html:<h3>Do you have a garage?</h3>
 https://www.youtube.com/watch?v=EwXLwxZom-o CAR HAVE? DOORS HOW-MANY?
-  more+ html:<h3>Do you have a car?—if so—How many doors?</h3>
+  more: +html:<h3>Do you have a car?—if so—How many doors?</h3>
 https://www.youtube.com/watch?v=hkecqnDiaJo
   YOUR HOUSE, GARBAGE, WHO THROW-OUT WHO?
-  more+ html:<h3>Who takes out the garbage in your house?</h3>
+  more: +html:<h3>Who takes out the garbage in your house?</h3>
 https://www.youtube.com/watch?v=0kwqwUJlso8
   YOUR DRYER, G-A-S, [bodyshift] ELECTRIC WHICH?
-  more+ html:<h3>Is your clothes dryer gas or electric?</h3>
+  more: +html:<h3>Is your clothes dryer gas or electric?</h3>
 https://www.youtube.com/watch?v=9JzidNeA5iA THAT TABLE, COLOR?
-  more+ html:<h3>What color is that table?</h3>
+  more: +html:<h3>What color is that table?</h3>
 https://www.youtube.com/watch?v=10HFEXWltKk TOOTHPASTE YOU, what-KIND?
   trim: 24F-162F
-  more+ html:<h3>What kind of toothpaste do you use?</h3>
+  more: +html:<h3>What kind of toothpaste do you use?</h3>
 https://www.youtube.com/watch?v=0MYgfrV6Th8 YOU PREFER STOVE, MICROWAVE, WHICH?
-  more+ html:<h3>Would you rather cook using a stove or a microwave?</h3>
+  more: +html:<h3>Would you rather cook using a stove or a microwave?</h3>
 https://www.youtube.com/watch?v=n5_TdPKADaU YOUR REFRIGERATOR, what-COLOR?
-  more+ html:<h3>What color is your fridge?</h3>
+  more: +html:<h3>What color is your fridge?</h3>
 https://www.youtube.com/watch?v=d1nuU-xC9x8 AMBULANCE, PAST-[before] YOU?
   trim: 48F-124F
-  more+ html:<h3>Have you ever been in an ambulance?</h3>
+  more: +html:<h3>Have you ever been in an ambulance?</h3>
 https://www.youtube.com/watch?v=NNFndv9Iq4I DEAF PREFER KITCHEN, WHY?
-  more+ html:<h3>Why do deaf people tend to gather in the kitchen? (Better lighting)</h3>
+  more: +html:<h3>Why do deaf people tend to gather in the kitchen? (Better lighting)</h3>
 https://www.youtube.com/watch?v=lASo3dg0qT4 YESTERDAY YOU SHOWER YOU?
-  more+ html:<h3>Did you shower yesterday?</h3>
+  more: +html:<h3>Did you shower yesterday?</h3>
 https://www.youtube.com/watch?v=f3kOB5Ickng YOUR S-I-N-K, COLOR?
-  more+ html:<h3>What color is your sink?</h3>
+  more: +html:<h3>What color is your sink?</h3>
 https://www.youtube.com/watch?v=LmU-zv4kPxA
   YOUR PANTS, YOU PUT DRESSER, HANG-UP WHICH?
-  more+ html:<h3>Do you keep your pants in a dresser or do you hang them up?</h3>
+  more: +html:<h3>Do you keep your pants in a dresser or do you hang them up?</h3>
 https://www.youtube.com/watch?v=p2KPT9qSvdY YOUR BEDROOM HAVE WINDOW?
-  more+ html:<h3>Is there a window in your bedroom?</h3>
+  more: +html:<h3>Is there a window in your bedroom?</h3>

--- a/asl/lesson-09.deck
+++ b/asl/lesson-09.deck
@@ -7,232 +7,232 @@ note_id: Lifeprint ASL {url} {clip}
 
 https://www.youtube.com/watch?v=bL5R1zZXaRY BASEMENT
   trim: 10F-72F
-  more+ rst:`BASEMENT <https://www.lifeprint.com/asl101/pages-signs/b/basement.htm>`_
+  more: +rst:`BASEMENT <https://www.lifeprint.com/asl101/pages-signs/b/basement.htm>`_
 
 https://www.youtube.com/watch?v=HCOkhtgWKxs BATH TUB
   trim: 9F-75F
-  more+ rst:`BATHTUB <https://www.lifeprint.com/asl101/pages-signs/b/bathtub.htm>`_
+  more: +rst:`BATHTUB <https://www.lifeprint.com/asl101/pages-signs/b/bathtub.htm>`_
 https://www.youtube.com/watch?v=r8wxFtDjU5Y BATH
   trim: 10F-72F
-  more+ rst:`BATHTUB <https://www.lifeprint.com/asl101/pages-signs/b/bathtub.htm>`_
+  more: +rst:`BATHTUB <https://www.lifeprint.com/asl101/pages-signs/b/bathtub.htm>`_
   tags: +first_100_signs
 
 https://www.youtube.com/watch?v=ZcJGws8g8uE COUCH
   trim: 14F-87F
-  more+ rst:`COUCH <https://www.lifeprint.com/asl101/pages-signs/c/couch.htm>`_
+  more: +rst:`COUCH <https://www.lifeprint.com/asl101/pages-signs/c/couch.htm>`_
 
 https://www.youtube.com/watch?v=xzIU5tmBrLc
   DOOR / cupboard / closet / cabinet / locker
   trim: 11F-77F
-  more+ rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
+  more: +rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
 https://www.youtube.com/watch?v=SDTlfgtJKlI OPEN-DOOR
   trim: 17F-85F
-  more+ rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
+  more: +rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
 https://www.youtube.com/watch?v=kCiFi6IQpBE CLOSE-DOOR
   trim: 14F-79F
-  more+ rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
+  more: +rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
 https://www.youtube.com/watch?v=LEWPXaskrJk OPEN
   trim: 22F-77F
-  more+ rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
+  more: +rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
 https://www.youtube.com/watch?v=adXm1AhwMBM CLOSE / CLOSED
   trim: 25F-85F
-  more+ rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
+  more: +rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
 
 https://www.youtube.com/watch?v=9G23AjmjyV4 DRESSER / DRAWER
   trim: 13F-76F
-  more+ rst:`DRESSER <https://www.lifeprint.com/asl101/pages-signs/d/dresser.htm>`_
+  more: +rst:`DRESSER <https://www.lifeprint.com/asl101/pages-signs/d/dresser.htm>`_
 
 https://www.youtube.com/watch?v=NuXm0_3x6n8 DRY
   trim: 9F-64F
-  more+ rst:`DRYER <https://www.lifeprint.com/asl101/pages-signs/d/dryer.htm>`_
+  more: +rst:`DRYER <https://www.lifeprint.com/asl101/pages-signs/d/dryer.htm>`_
 https://www.youtube.com/watch?v=OF3KatN3TgU DRYER-[DRY-DRY-version]
   trim: 11F-54F
-  more+ rst:`DRYER <https://www.lifeprint.com/asl101/pages-signs/d/dryer.htm>`_
+  more: +rst:`DRYER <https://www.lifeprint.com/asl101/pages-signs/d/dryer.htm>`_
 https://www.youtube.com/watch?v=HsCGIr9TDbE DRYER-[DRY-spin-around-version]
   trim: 8F-72F
-  more+ rst:`DRYER <https://www.lifeprint.com/asl101/pages-signs/d/dryer.htm>`_
+  more: +rst:`DRYER <https://www.lifeprint.com/asl101/pages-signs/d/dryer.htm>`_
 
 https://www.youtube.com/watch?v=6i1516QNfaY GARAGE
   trim: 15F-
-  more+ rst:`GARAGE <https://www.lifeprint.com/asl101/pages-signs/g/garage.htm>`_
+  more: +rst:`GARAGE <https://www.lifeprint.com/asl101/pages-signs/g/garage.htm>`_
 
 # I’m unsure about my interpretation of THROW-OUT and THROW-AWAY
 https://www.youtube.com/watch?v=sHFqJ68Ev8o GARBAGE / trash
   trim: 4F-
-  more+ rst:`GARBAGE <https://www.lifeprint.com/asl101/pages-signs/g/garbage.htm>`_
+  more: +rst:`GARBAGE <https://www.lifeprint.com/asl101/pages-signs/g/garbage.htm>`_
 https://www.youtube.com/watch?v=TCopmoEfXaw THROW-AWAY (small variant)
   trim: 14F-44F
-  more+ rst:`GARBAGE <https://www.lifeprint.com/asl101/pages-signs/g/garbage.htm>`_
+  more: +rst:`GARBAGE <https://www.lifeprint.com/asl101/pages-signs/g/garbage.htm>`_
 https://www.youtube.com/watch?v=TnWogCQKnXQ THROW-OUT (big variant)
   trim: 9F-74F
-  more+ rst:`GARBAGE <https://www.lifeprint.com/asl101/pages-signs/g/garbage.htm>`_
+  more: +rst:`GARBAGE <https://www.lifeprint.com/asl101/pages-signs/g/garbage.htm>`_
 
 https://www.youtube.com/watch?v=-yEO1YL7dSg KITCHEN (“cook” variation)
   trim: 15F-79F
-  more+ rst:`KITCHEN <https://www.lifeprint.com/asl101/pages-signs/k/kitchen.htm>`_
+  more: +rst:`KITCHEN <https://www.lifeprint.com/asl101/pages-signs/k/kitchen.htm>`_
 https://www.youtube.com/watch?v=u6KL0UFbL5M KITCHEN (one-handed variation)
   trim: 6F-64F
-  more+ rst:`KITCHEN <https://www.lifeprint.com/asl101/pages-signs/k/kitchen.htm>`_
+  more: +rst:`KITCHEN <https://www.lifeprint.com/asl101/pages-signs/k/kitchen.htm>`_
 https://www.youtube.com/watch?v=Xy0FCuz1KHw COOK / KITCHEN
   trim: 12F-70F
-  more+ rst:`KITCHEN <https://www.lifeprint.com/asl101/pages-signs/k/kitchen.htm>`_
+  more: +rst:`KITCHEN <https://www.lifeprint.com/asl101/pages-signs/k/kitchen.htm>`_
 
 # LIGHTS / LIGHTS-ON is in lesson 8
 https://www.youtube.com/watch?v=u33E8wPkfyU LIGHTS-FLASH
   trim: 11F-57F
-  more+ rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
+  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
 https://www.youtube.com/watch?v=aCIocBQ6ylU
   LIGHT-device / LIGHT-bulb / LIGHT (general)
   trim: 9F-102F
-  more+ rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
+  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
 https://www.youtube.com/watch?v=uKSJnAaaXBE BRIGHT / CLEAR / OBVIOUS
   trim: 10F-71F
-  more+ rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
+  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
 
 tags: +extra
 https://www.youtube.com/watch?v=fnYd3XHdEPI RAY-of-light / SUN-ray
   trim: 28F-78F
-  more+ rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
+  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
 https://www.youtube.com/watch?v=KOKG7jy8Loo LAMP
   trim: 13F-70F
-  more+ rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
+  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
 https://www.youtube.com/watch?v=dTjopMLqGIQ HEADLIGHTS
   trim: 37F-88F
-  more+ rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
+  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
 https://www.youtube.com/watch?v=C37R_Ix8-qs LIGHT-A-MATCH
   trim: 11F-72F
-  more+ rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
+  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
 https://www.youtube.com/watch?v=lnbXEMxYdn4 AMBULANCE / LIGHTS-rotating-flashing
   trim: 13F-86F
-  more+ rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
+  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
 https://www.youtube.com/watch?v=_zgfuzlhI9Q LIGHT-WEIGHT
   trim: 25F-92F
-  more+ rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
+  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
 tags: -extra
 
 https://www.youtube.com/watch?v=kzvEJrS357s MICROWAVE
   trim: 9F-57F
-  more+ rst:`MICROWAVE <https://www.lifeprint.com/asl101/pages-signs/m/microwave.htm>`_
+  more: +rst:`MICROWAVE <https://www.lifeprint.com/asl101/pages-signs/m/microwave.htm>`_
 https://www.youtube.com/watch?v=AxUJzzak-z0 -> MICROWAVE (3 fingers version)
   trim: 9F-54F
-  more+ rst:`MICROWAVE <https://www.lifeprint.com/asl101/pages-signs/m/microwave.htm>`_
+  more: +rst:`MICROWAVE <https://www.lifeprint.com/asl101/pages-signs/m/microwave.htm>`_
 
 https://www.youtube.com/watch?v=LOW8ZIaAJ-c REFRIGERATOR
   trim: 7F-67F
-  more+ html:<h1>#REF</h1>
-  more+ rst:`REFRIGERATOR <https://www.lifeprint.com/asl101/pages-signs/r/refrigerator.htm>`_
+  more: +html:<h1>#REF</h1>
+  more: +rst:`REFRIGERATOR <https://www.lifeprint.com/asl101/pages-signs/r/refrigerator.htm>`_
 # No video for REFRIGERATOR version with R-hands like COLD
 
 https://www.youtube.com/watch?v=iJ8TFRWJutE SHOWER
   trim: 11F-58F
-  more+ rst:`SHOWER <https://www.lifeprint.com/asl101/pages-signs/s/shower.htm>`_
+  more: +rst:`SHOWER <https://www.lifeprint.com/asl101/pages-signs/s/shower.htm>`_
 
 https://www.youtube.com/watch?v=iZJAZYXj-Gw #SINK
   trim: 11F-61F
-  more+ rst:`SINK <https://www.lifeprint.com/asl101/pages-signs/s/sink.htm>`_
+  more: +rst:`SINK <https://www.lifeprint.com/asl101/pages-signs/s/sink.htm>`_
 
 tags: +extra
 https://www.youtube.com/watch?v=fwnMkFs7sdc SINK (depictive version)
   trim: 4F-
-  more+ rst:`SINK <https://www.lifeprint.com/asl101/pages-signs/s/sink.htm>`_
+  more: +rst:`SINK <https://www.lifeprint.com/asl101/pages-signs/s/sink.htm>`_
 https://www.youtube.com/watch?v=TIi1dumlqjE SINK (verb) / to become submerged
   trim: 8F-58F
-  more+ rst:`SINK <https://www.lifeprint.com/asl101/pages-signs/s/sink.htm>`_
+  more: +rst:`SINK <https://www.lifeprint.com/asl101/pages-signs/s/sink.htm>`_
 tags: -extra
 
 https://www.youtube.com/watch?v=c75leThE9AQ #STOVE
   trim: 11F-62F
-  more+ rst:`STOVE <https://www.lifeprint.com/asl101/pages-signs/s/stove.htm>`_
+  more: +rst:`STOVE <https://www.lifeprint.com/asl101/pages-signs/s/stove.htm>`_
 
 tags: +extra
 https://www.youtube.com/watch?v=3_2Zyn10sZI #OVEN
   trim: 22F-86F
-  more+ rst:`STOVE <https://www.lifeprint.com/asl101/pages-signs/s/stove.htm>`_
+  more: +rst:`STOVE <https://www.lifeprint.com/asl101/pages-signs/s/stove.htm>`_
 https://www.youtube.com/watch?v=bf1X67Lhu6A OVEN / BAKING
-  more+ rst:`STOVE <https://www.lifeprint.com/asl101/pages-signs/s/stove.htm>`_
+  more: +rst:`STOVE <https://www.lifeprint.com/asl101/pages-signs/s/stove.htm>`_
 https://www.youtube.com/watch?v=Q0vD9t1u5bI BAKE
   trim: 14F-67F
-  more+ rst:`STOVE <https://www.lifeprint.com/asl101/pages-signs/s/stove.htm>`_
+  more: +rst:`STOVE <https://www.lifeprint.com/asl101/pages-signs/s/stove.htm>`_
 tags: -extra
 
 https://www.youtube.com/watch?v=UJINxF1cSUA TABLE / DESK
   trim: 11F-73F
-  more+ rst:`TABLE <https://www.lifeprint.com/asl101/pages-signs/t/table.htm>`_
+  more: +rst:`TABLE <https://www.lifeprint.com/asl101/pages-signs/t/table.htm>`_
 
 https://www.youtube.com/watch?v=VqFX50Z9Y60 WINDOW
   trim: 10F-75F
-  more+ rst:`WINDOW <https://www.lifeprint.com/asl101/pages-signs/w/window.htm>`_
+  more: +rst:`WINDOW <https://www.lifeprint.com/asl101/pages-signs/w/window.htm>`_
 https://www.youtube.com/watch?v=C_e84lDOEoU OPEN-WINDOW
   trim: 10F-69F
-  more+ rst:`WINDOW <https://www.lifeprint.com/asl101/pages-signs/w/window.htm>`_
+  more: +rst:`WINDOW <https://www.lifeprint.com/asl101/pages-signs/w/window.htm>`_
 https://www.youtube.com/watch?v=a5IIsvDsjcQ CLOSE-WINDOW
   trim: 10F-72F
-  more+ rst:`WINDOW <https://www.lifeprint.com/asl101/pages-signs/w/window.htm>`_
+  more: +rst:`WINDOW <https://www.lifeprint.com/asl101/pages-signs/w/window.htm>`_
 
 https://www.youtube.com/watch?v=BrSb83b9kbY YESTERDAY
   trim: 13F-72F
-  more+ rst:`YESTERDAY <https://www.lifeprint.com/asl101/pages-signs/y/yesterday.htm>`_
+  more: +rst:`YESTERDAY <https://www.lifeprint.com/asl101/pages-signs/y/yesterday.htm>`_
 https://www.youtube.com/watch?v=WaIrad_avQI -> YESTERDAY (initialized)
   trim: 30F-89F
-  more+ rst:`YESTERDAY <https://www.lifeprint.com/asl101/pages-signs/y/yesterday.htm>`_
+  more: +rst:`YESTERDAY <https://www.lifeprint.com/asl101/pages-signs/y/yesterday.htm>`_
   tags: +extra
 
 # SAY is in lesson 5 extra
 https://www.youtube.com/watch?v=-Dv4nnY_F18 what-SAY / What was said?
   trim: 9F-57F
-  more+ rst:`SAY <https://www.lifeprint.com/asl101/pages-signs/s/say.htm>`_
+  more: +rst:`SAY <https://www.lifeprint.com/asl101/pages-signs/s/say.htm>`_
   tags: +extra
 
 https://www.youtube.com/watch?v=6IXVVDel4lw TOOTHPASTE
   trim: 13F-74F
-  more+ rst:`TOOTHPASTE <https://www.lifeprint.com/asl101/pages-signs/t/toothpaste.htm>`_
+  more: +rst:`TOOTHPASTE <https://www.lifeprint.com/asl101/pages-signs/t/toothpaste.htm>`_
 
 https://www.youtube.com/watch?v=7Z1WMbq2Y6E AHEAD
   trim: 9F-77F
-  more+ rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
+  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
 https://www.youtube.com/watch?v=VoetY5cF1Oo BEHIND
   trim: 8F-67F
-  more+ rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
+  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
 https://www.youtube.com/watch?v=l2fU_9FofrE FALL-BEHIND
   trim: 10F-69F
-  more+ rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
+  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
 https://www.youtube.com/watch?v=ESOxu86BLGw AVOID
   trim: 57F-116F
-  more+ rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
+  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
 https://www.youtube.com/watch?v=6ywnNz3BaMk FOLLOW / following / obey
   trim: 4F-53F
-  more+ rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
+  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
 https://www.youtube.com/watch?v=P0g3SiRW__4 CATCH-UP
   trim: 6F-65F
-  more+ rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
+  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
 https://www.youtube.com/watch?v=PNp3dIAoFGA CHASE
   trim: 11F-69F
-  more+ rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
+  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
 https://www.youtube.com/watch?v=H37s1WoEGEs RACE / COMPETE
   trim: 7F-68F
-  more+ rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
+  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
 https://www.youtube.com/watch?v=Esuc74eXfMA UNDER / SUBORDINATE
   trim: 16F-75F
-  more+ rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
+  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
 https://www.youtube.com/watch?v=jQC2QdxW9u0 ABOVE / SUPERIOR
   trim: 16F-88F
-  more+ rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
+  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
 
 # From video
 tags: +extra
 https://www.youtube.com/watch?v=DyYb5Y2efP4 APARTMENT
   trim: 8F-72F
-  more+ html:<h1>#APT</h1>
-  more+ rst:`APARTMENT <https://www.lifeprint.com/asl101/pages-signs/a/apartment.htm>`_
+  more: +html:<h1>#APT</h1>
+  more: +rst:`APARTMENT <https://www.lifeprint.com/asl101/pages-signs/a/apartment.htm>`_
 
 https://www.youtube.com/watch?v=G4HZ1OaQHpI THAT (non-specific, one handed)
   trim: 4F-56F
-  more+ rst:`THAT <https://www.lifeprint.com/asl101/pages-signs/t/that.htm>`_
+  more: +rst:`THAT <https://www.lifeprint.com/asl101/pages-signs/t/that.htm>`_
 https://www.youtube.com/watch?v=tNas8PN6pIQ THAT (specific, Y-hand)
   trim: 12F-51F
-  more+ rst:`THAT <https://www.lifeprint.com/asl101/pages-signs/t/that.htm>`_
+  more: +rst:`THAT <https://www.lifeprint.com/asl101/pages-signs/t/that.htm>`_
 https://www.youtube.com/watch?v=IujovunU_X8 THAT (non-specific, two handed)
   trim: 0-60F
-  more+ rst:`THAT <https://www.lifeprint.com/asl101/pages-signs/t/that.htm>`_
+  more: +rst:`THAT <https://www.lifeprint.com/asl101/pages-signs/t/that.htm>`_
 
 # Couldn’t find video for [natural]-GAS or G-A-S.

--- a/asl/lesson-10.deck
+++ b/asl/lesson-10.deck
@@ -9,11 +9,11 @@ note_id: Lifeprint ASL {url} {clip}
 
 https://www.youtube.com/watch?v=Pszo0ZVIcUA CHICKEN / BIRD
   trim: 10F-60F
-  more+ rst:`BIRD <https://www.lifeprint.com/asl101/pages-signs/b/bird.htm>`_
+  more: +rst:`BIRD <https://www.lifeprint.com/asl101/pages-signs/b/bird.htm>`_
   tags: +first_100_signs
 
 https://www.youtube.com/watch?v=yxlQDmsFo-g ->
-  more+ rst:`CHICKEN <https://www.lifeprint.com/asl101/pages-signs/c/chicken.htm>`_
+  more: +rst:`CHICKEN <https://www.lifeprint.com/asl101/pages-signs/c/chicken.htm>`_
   CHICKEN (old version — pecking in hand)
 
 https://www.youtube.com/watch?v=a3b8LAX68Ho CAT (F hand version)

--- a/tests/syntax_test.py
+++ b/tests/syntax_test.py
@@ -21,3 +21,26 @@ def test_two_mores():
         ).config.more.render_html()
         == "onetwo"
     )
+
+
+def test_overlays():
+    assert (
+        parse_deck(
+            textwrap.dedent("""
+                title: a
+                overlay_text: one
+            """)
+        ).config.overlay_text
+        == "one"
+    )
+
+    assert (
+        parse_deck(
+            textwrap.dedent("""
+                title: a
+                overlay_text: one
+                overlay_text: +two
+            """)
+        ).config.overlay_text
+        == "onetwo"
+    )

--- a/tests/syntax_test.py
+++ b/tests/syntax_test.py
@@ -18,6 +18,6 @@ def test_two_mores():
                 more: one
                 more+ two
             """)
-        ).scope.more.render_html()
+        ).config.more.render_html()
         == "onetwo"
     )

--- a/tests/syntax_test.py
+++ b/tests/syntax_test.py
@@ -1,11 +1,14 @@
 import io
+import pytest
 import textwrap
 
-from yanki.parser import DeckParser
+from yanki.parser import DeckParser, DeckSyntaxError
 
 
 def parse_deck(contents, name="-"):
-    specs = list(DeckParser().parse_file(name, io.StringIO(contents)))
+    specs = list(
+        DeckParser().parse_file(name, io.StringIO(textwrap.dedent(contents)))
+    )
     assert len(specs) == 1
     return specs[0]
 
@@ -13,11 +16,11 @@ def parse_deck(contents, name="-"):
 def test_two_mores():
     assert (
         parse_deck(
-            textwrap.dedent("""
+            """
                 title: a
                 more: one
                 more: +two
-            """)
+            """
         ).config.more.render_html()
         == "onetwo"
     )
@@ -26,21 +29,147 @@ def test_two_mores():
 def test_overlays():
     assert (
         parse_deck(
-            textwrap.dedent("""
+            """
                 title: a
                 overlay_text: one
-            """)
+            """
         ).config.overlay_text
         == "one"
     )
 
     assert (
         parse_deck(
-            textwrap.dedent("""
+            """
                 title: a
                 overlay_text: one
                 overlay_text: +two
-            """)
+            """
         ).config.overlay_text
         == "onetwo"
     )
+
+
+def test_deck_config_whitespace():
+    assert (
+        parse_deck(
+            """
+                title: a
+                overlay_text: one"""
+        ).config.overlay_text
+        == "one"
+    )
+
+    assert (
+        parse_deck(
+            """
+                title: a
+                overlay_text: one
+                overlay_text:"""
+        ).config.overlay_text
+        == ""
+    )
+
+    assert (
+        parse_deck(
+            """
+                title: a
+                overlay_text: one
+                overlay_text:     \t"""
+        ).config.overlay_text
+        == ""
+    )
+
+    assert (
+        parse_deck(
+            """
+                title: a
+                overlay_text: one
+                overlay_text:
+            """
+        ).config.overlay_text
+        == ""
+    )
+
+
+def test_note_config_whitespace():
+    deck = parse_deck(
+        """
+            title: a
+            overlay_text: deck
+
+            file:///foo note
+                overlay_text: one
+        """
+    )
+    assert deck.config.overlay_text == "deck"
+    assert deck.note_specs[0].config.overlay_text == "one"
+
+    deck = parse_deck(
+        """
+            title: a
+            overlay_text: deck
+
+            file:///foo note
+                overlay_text: one"""
+    )
+    assert deck.config.overlay_text == "deck"
+    assert deck.note_specs[0].config.overlay_text == "one"
+
+    deck = parse_deck(
+        """
+            title: a
+            overlay_text: deck
+
+            file:///foo note
+                overlay_text:"""
+    )
+    assert deck.config.overlay_text == "deck"
+    assert deck.note_specs[0].config.overlay_text == ""
+
+    deck = parse_deck(
+        """
+            title: a
+            overlay_text: deck
+
+            file:///foo note
+                overlay_text:     \t"""
+    )
+    assert deck.config.overlay_text == "deck"
+    assert deck.note_specs[0].config.overlay_text == ""
+
+    deck = parse_deck(
+        """
+            title: a
+            overlay_text: deck
+
+            file:///foo note
+                overlay_text:
+        """
+    )
+    assert deck.config.overlay_text == "deck"
+    assert deck.note_specs[0].config.overlay_text == ""
+
+
+def test_bad_config():
+    with pytest.raises(DeckSyntaxError) as error_info:
+        parse_deck(
+            """
+                title: a
+                illegal: deck
+
+                file:///foo note
+                    overlay_text: one
+            """
+        )
+    assert error_info.match("Invalid config directive 'illegal'")
+
+    with pytest.raises(DeckSyntaxError) as error_info:
+        parse_deck(
+            """
+                title: a
+
+                file:///foo note
+                    illegal2: one
+            """
+        )
+    assert error_info.match("Invalid config directive 'illegal2'")

--- a/tests/syntax_test.py
+++ b/tests/syntax_test.py
@@ -16,7 +16,7 @@ def test_two_mores():
             textwrap.dedent("""
                 title: a
                 more: one
-                more+ two
+                more: +two
             """)
         ).config.more.render_html()
         == "onetwo"

--- a/yanki/anki.py
+++ b/yanki/anki.py
@@ -125,24 +125,24 @@ class Note:
                 options=self.video_options,
                 logger=self.logger,
             )
-            video.audio(self.spec.scope.audio)
-            video.video(self.spec.scope.video)
-            if self.spec.scope.crop:
-                video.crop(self.spec.scope.crop)
-            if self.spec.scope.trim:
-                video.clip(self.spec.scope.trim[0], self.spec.scope.trim[1])
-            if self.spec.scope.format:
-                video.format(self.spec.scope.format)
-            if self.spec.scope.slow:
-                (start, end, amount) = self.spec.scope.slow
+            video.audio(self.spec.config.audio)
+            video.video(self.spec.config.video)
+            if self.spec.config.crop:
+                video.crop(self.spec.config.crop)
+            if self.spec.config.trim:
+                video.clip(self.spec.config.trim[0], self.spec.config.trim[1])
+            if self.spec.config.format:
+                video.format(self.spec.config.format)
+            if self.spec.config.slow:
+                (start, end, amount) = self.spec.config.slow
                 video.slow(start=start, end=end, amount=amount)
-            if self.spec.scope.overlay_text:
-                video.overlay_text(self.spec.scope.overlay_text)
+            if self.spec.config.overlay_text:
+                video.overlay_text(self.spec.config.overlay_text)
         except ValueError as error:
             self.spec.error(error)
 
         if self.spec.clip() is not None:
-            if self.spec.scope.trim is not None:
+            if self.spec.config.trim is not None:
                 self.spec.error(
                     f"Clip ({self.spec.provisional_clip_spec()!r}) is "
                     "incompatible with 'trim:'."
@@ -160,7 +160,7 @@ class Note:
     # {deck_id} is just a placeholder. To get the real note_id, you need to have
     # a deck_id.
     def note_id(self, deck_id="{deck_id}"):
-        return self.spec.scope.generate_note_id(
+        return self.spec.config.generate_note_id(
             **self.variables(deck_id=deck_id),
         )
 
@@ -248,7 +248,7 @@ class FinalNote:
         return Field([Fragment(self.text)])
 
     def more_field(self):
-        return self.spec.scope.more
+        return self.spec.config.more
 
     def media_field(self):
         return Field([self.media_fragment])
@@ -301,7 +301,7 @@ class FinalNote:
                 media_to_text,
             ],
             guid=genanki.guid_for(self.note_id),
-            tags=self.spec.scope.tags,
+            tags=self.spec.config.tags,
         )
 
 
@@ -387,7 +387,7 @@ class Deck:
         return name_to_id(self.title())
 
     def title(self):
-        return self.spec.scope.title
+        return self.spec.config.title
 
     def source_path(self):
         return self.spec.source_path

--- a/yanki/anki.py
+++ b/yanki/anki.py
@@ -387,7 +387,7 @@ class Deck:
         return name_to_id(self.title())
 
     def title(self):
-        return self.spec.config.title
+        return self.spec.title
 
     def source_path(self):
         return self.spec.source_path

--- a/yanki/parser.py
+++ b/yanki/parser.py
@@ -46,7 +46,7 @@ class DeckSyntaxError(ExpectedError):
         return f"{self.source_path}, line {self.line_number}"
 
 
-class Scope:
+class Config:
     def __init__(self):
         self.title = None
         self.crop = None
@@ -165,11 +165,11 @@ class NoteSpec:
     source_path: str
     line_number: int
     source: str  # config directives are stripped from this
-    scope: Scope
+    config: Config
 
     @functools.cache
     def provisional_note_id(self, deck_id="{deck_id}"):
-        return self.scope.generate_note_id(
+        return self.config.generate_note_id(
             deck_id=deck_id,
             url=self.video_url(),
             clip=self.provisional_clip_spec(),
@@ -244,7 +244,7 @@ class NoteSpec:
 class DeckSpec:
     def __init__(self, source_path):
         self.source_path = source_path
-        self.scope = Scope()
+        self.config = Config()
         self.note_specs = []
 
     def add_note_spec(self, note_spec: NoteSpec):
@@ -265,7 +265,7 @@ class DeckParser:
     def _reset_note(self):
         """Reset working note data."""
         self.note_source = []
-        self.note_scope = None
+        self.note_config = None
         self.note_line_number = None
 
     def open(self, path):
@@ -280,7 +280,7 @@ class DeckParser:
         if len(self.note_source) > 0:
             self._finish_note()
 
-        if self.working_deck.scope.title is None:
+        if self.working_deck.config.title is None:
             raise DeckSyntaxError(
                 "Does not contain title",
                 self.working_deck.source_path,
@@ -341,10 +341,10 @@ class DeckParser:
                     "Found indented line with no preceding unindented line"
                 )
 
-            if self.note_scope is None:
-                self.note_scope = deepcopy(self.working_deck.scope)
+            if self.note_config is None:
+                self.note_config = deepcopy(self.working_deck.config)
 
-            unindented = self._check_for_config(unindented, self.note_scope)
+            unindented = self._check_for_config(unindented, self.note_config)
             if unindented is not None:
                 self.note_source.append(unindented)
             return
@@ -359,13 +359,13 @@ class DeckParser:
         if len(self.note_source) > 0:
             self._finish_note()
 
-        line = self._check_for_config(line, self.working_deck.scope)
+        line = self._check_for_config(line, self.working_deck.config)
         if line is not None:
             if len(self.note_source) == 0:
                 self.note_line_number = self.line_number
             self.note_source.append(line)
 
-    def _check_for_config(self, line, scope):
+    def _check_for_config(self, line, config):
         # Line without newline
         line_chomped = line.rstrip("\n\r")
 
@@ -375,31 +375,31 @@ class DeckParser:
 
         try:
             if line.startswith("title:"):
-                scope.title = line.removeprefix("title:").strip()
+                config.title = line.removeprefix("title:").strip()
             elif line.startswith("more:"):
-                scope.set_more(line.removeprefix("more:").strip())
+                config.set_more(line.removeprefix("more:").strip())
             elif line.startswith("more+"):
-                scope.add_more(line.removeprefix("more+").strip())
+                config.add_more(line.removeprefix("more+").strip())
             elif line.startswith("overlay_text:"):
-                scope.set_overlay_text(
+                config.set_overlay_text(
                     line.removeprefix("overlay_text:").strip()
                 )
             elif line.startswith("tags:"):
-                scope.update_tags(line.removeprefix("tags:"))
+                config.update_tags(line.removeprefix("tags:"))
             elif line.startswith("crop:"):
-                scope.crop = line.removeprefix("crop:").strip()
+                config.crop = line.removeprefix("crop:").strip()
             elif line.startswith("format:"):
-                scope.format = line.removeprefix("format:").strip()
+                config.format = line.removeprefix("format:").strip()
             elif line.startswith("trim:"):
-                scope.set_trim(line.removeprefix("trim:").strip())
+                config.set_trim(line.removeprefix("trim:").strip())
             elif line.startswith("slow:"):
-                scope.add_slow(line.removeprefix("slow:").strip())
+                config.add_slow(line.removeprefix("slow:").strip())
             elif line.startswith("audio:"):
-                scope.set_audio(line.removeprefix("audio:").strip())
+                config.set_audio(line.removeprefix("audio:").strip())
             elif line.startswith("video:"):
-                scope.set_video(line.removeprefix("video:").strip())
+                config.set_video(line.removeprefix("video:").strip())
             elif line.startswith("note_id"):
-                scope.set_note_id_format(line.removeprefix("note_id:").strip())
+                config.set_note_id_format(line.removeprefix("note_id:").strip())
             else:
                 return line
         except ValueError as error:
@@ -410,8 +410,8 @@ class DeckParser:
     def _finish_note(self):
         self.working_deck.add_note_spec(
             NoteSpec(
-                # FIXME is self.note_scope is None possible?
-                scope=self.note_scope or deepcopy(self.working_deck.scope),
+                # FIXME is self.note_config is None possible?
+                config=self.note_config or deepcopy(self.working_deck.config),
                 source_path=self.working_deck.source_path,
                 line_number=self.note_line_number,
                 source="".join(self.note_source),

--- a/yanki/parser.py
+++ b/yanki/parser.py
@@ -48,7 +48,6 @@ class DeckSyntaxError(ExpectedError):
 
 class NoteConfig:
     def __init__(self):
-        self.title = None
         self.crop = None
         self.format = None
         self.more = Field()
@@ -243,6 +242,7 @@ class NoteSpec:
 
 class DeckSpec:
     def __init__(self, source_path):
+        self.title = None
         self.source_path = source_path
         self.config = NoteConfig()
         self.note_specs = []
@@ -280,7 +280,7 @@ class DeckParser:
         if len(self.note_source) > 0:
             self._finish_note()
 
-        if self.working_deck.config.title is None:
+        if self.working_deck.title is None:
             raise DeckSyntaxError(
                 "Does not contain title",
                 self.working_deck.source_path,
@@ -375,7 +375,7 @@ class DeckParser:
 
         try:
             if line.startswith("title:"):
-                config.title = line.removeprefix("title:").strip()
+                self.working_deck.title = line.removeprefix("title:").strip()
             elif line.startswith("more:"):
                 config.set_more(line.removeprefix("more:").strip())
             elif line.startswith("more+"):

--- a/yanki/parser.py
+++ b/yanki/parser.py
@@ -46,7 +46,7 @@ class DeckSyntaxError(ExpectedError):
         return f"{self.source_path}, line {self.line_number}"
 
 
-class Config:
+class NoteConfig:
     def __init__(self):
         self.title = None
         self.crop = None
@@ -165,7 +165,7 @@ class NoteSpec:
     source_path: str
     line_number: int
     source: str  # config directives are stripped from this
-    config: Config
+    config: NoteConfig
 
     @functools.cache
     def provisional_note_id(self, deck_id="{deck_id}"):
@@ -244,7 +244,7 @@ class NoteSpec:
 class DeckSpec:
     def __init__(self, source_path):
         self.source_path = source_path
-        self.config = Config()
+        self.config = NoteConfig()
         self.note_specs = []
 
     def add_note_spec(self, note_spec: NoteSpec):

--- a/yanki/parser.py
+++ b/yanki/parser.py
@@ -66,7 +66,10 @@ class NoteConfig:
             self.more = Field([Fragment(input)])
 
     def set_overlay_text(self, input):
-        self.overlay_text = input
+        if input.startswith("+"):
+            self.overlay_text += input[1:]
+        else:
+            self.overlay_text = input
 
     def update_tags(self, input):
         new_tags = input.split()

--- a/yanki/parser.py
+++ b/yanki/parser.py
@@ -398,7 +398,7 @@ class DeckParser:
                 config.set_audio(line.removeprefix("audio:").strip())
             elif line.startswith("video:"):
                 config.set_video(line.removeprefix("video:").strip())
-            elif line.startswith("note_id"):
+            elif line.startswith("note_id:"):
                 config.set_note_id_format(line.removeprefix("note_id:").strip())
             else:
                 return line

--- a/yanki/parser.py
+++ b/yanki/parser.py
@@ -60,10 +60,10 @@ class NoteConfig:
         self.note_id_format = "{deck_id} {url} {clip}"
 
     def set_more(self, input):
-        self.more = Field([Fragment(input)])
-
-    def add_more(self, input):
-        self.more.add_fragment(Fragment(input))
+        if input.startswith("+"):
+            self.more.add_fragment(Fragment(input[1:]))
+        else:
+            self.more = Field([Fragment(input)])
 
     def set_overlay_text(self, input):
         self.overlay_text = input
@@ -377,8 +377,6 @@ class DeckParser:
                 self.working_deck.title = line.removeprefix("title:").strip()
             elif line.startswith("more:"):
                 config.set_more(line.removeprefix("more:").strip())
-            elif line.startswith("more+"):
-                config.add_more(line.removeprefix("more+").strip())
             elif line.startswith("overlay_text:"):
                 config.set_overlay_text(
                     line.removeprefix("overlay_text:").strip()


### PR DESCRIPTION
- **Revert "Rename `Config` to `Scope`"**
  This reverts commit 92944d6732883749c1e7cce4641e9eb68745b3a1, and
  changes a other new instances of `scope` to `config`.
  
  I realized that `Scope` and `Config` are different things.
  

- **Rename `Config` to `NoteConfig`.**
  

- **Move `title` field from `NoteConfig` to `DeckSpec`.**
  

- **Switch parser to explicitly notice when a note starts.**
  

- **Switch `more+` syntax to `more: +`.**
  

- **Support `overlay_text: +` syntax.**
  

- **Fix: check for `note_id:` not `note_id` (missing colon).**
  

- **Move config directive handling into `NoteConfig`**
  This switches to expecting a consistent syntax for config directives and
  raising an error if it finds something that matches the syntax but is
  not a known config directive.
  
  It also moves the knowledge of what the config directives are (other
  than `title`) into `NoteConfig`.
  
  This makes `NoteConfig` a `dataclass`, and generates a frozen version of
  it to use with `NoteSpec`.
  