### PR TITLE
Fix: display bad variable when list-notes errors

### DIFF
--- a/yanki/cli.py
+++ b/yanki/cli.py
@@ -190,9 +190,8 @@ def list_notes(options, decks, format):
                 ### FIXME document variables
                 print(format.format(**note.variables(deck_id=deck.id())))
     else:
-        error = find_invalid_format(format, FINAL_NOTE_VARIABLES)
-        if error is not None:
-            sys.exit("Invalid variable in format: {error}")
+        if error := find_invalid_format(format, FINAL_NOTE_VARIABLES):
+            sys.exit(f"Invalid variable in format: {error}")
 
         for deck in read_final_decks(decks, options):
             for note in deck.notes():

--- a/yanki/html.py
+++ b/yanki/html.py
@@ -51,8 +51,7 @@ def htmlize_deck(deck, path_prefix=""):
         <h1>{h(deck.title)}</h1>"""
 
     for note in deck.notes():
-        more_html = note.more_field().render_html(path_prefix)
-        if more_html != "":
+        if more_html := note.more_field().render_html(path_prefix):
             more_html = f'<div class="more">{more_html}</div>'
         output += f"""
         <div class="note">

--- a/yanki/parser.py
+++ b/yanki/parser.py
@@ -188,8 +188,7 @@ class NoteConfig:
             raise ValueError('video must be either "include" or "strip"')
 
     def set_note_id(self, note_id):
-        error = find_invalid_format(note_id, NOTE_VARIABLES)
-        if error is not None:
+        if error := find_invalid_format(note_id, NOTE_VARIABLES):
             raise ValueError(f"Unknown variable in note_id format: {error}")
         self.note_id = note_id
 

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -137,8 +137,7 @@ class Video:
         self.reprocess = options.reprocess
 
         self.id = url_to_id(url)
-        invalid = chars_in(FILENAME_ILLEGAL_CHARS, self.id)
-        if invalid:
+        if invalid := chars_in(FILENAME_ILLEGAL_CHARS, self.id):
             raise BadURL(
                 f"Invalid characters ({''.join(invalid)}) in video ID: {self.id!r}"
             )
@@ -435,10 +434,9 @@ class Video:
 
         with yt_dlp.YoutubeDL(options) as ydl:
             # FIXME why not use the in-memory info?
-            error_code = ydl.download_with_info_file(self.info_cache_path())
-            if error_code:
+            if error := ydl.download_with_info_file(self.info_cache_path()):
                 # FIXME??!
-                raise RuntimeError(error_code)
+                raise RuntimeError(error)
 
         return path
 


### PR DESCRIPTION
This also switches a number of places to use `:=`.
