### PR TITLE
Syntax tests

### DIFF
--- a/tests/syntax_test.py
+++ b/tests/syntax_test.py
@@ -6,9 +6,9 @@ from yanki.parser import DeckParser, DeckSyntaxError
 
 
 def parse_deck(contents, name="-"):
-    specs = list(
-        DeckParser().parse_file(name, io.StringIO(textwrap.dedent(contents)))
-    )
+    # Strip extra indents and pretend it’s a file.
+    contents = io.StringIO(textwrap.dedent(contents))
+    specs = list(DeckParser().parse_file(name, contents))
     assert len(specs) == 1
     return specs[0]
 

--- a/tests/syntax_test.py
+++ b/tests/syntax_test.py
@@ -173,3 +173,33 @@ def test_bad_config():
             """
         )
     assert error_info.match("Invalid config directive 'illegal2'")
+
+
+def test_multiline_more():
+    with pytest.raises(DeckSyntaxError) as error_info:
+        assert (
+            parse_deck(
+                """
+                    title: a
+                    more: html:one
+                      two
+                """
+            ).config.more.render_html()
+            == "one\ntwo"
+        )
+    assert error_info.match("Found indented line ")
+
+
+def test_multiline_more_with_config():
+    with pytest.raises(DeckSyntaxError) as error_info:
+        assert (
+            parse_deck(
+                """
+                    title: a
+                    more: html:one
+                      more: two
+                """
+            ).config.more.render_html()
+            == "one\nmore: two"
+        )
+    assert error_info.match("Found indented line ")


### PR DESCRIPTION
- **Tests for multiline config directives**
  Currently this tests that they don’t work, but it includes `assert`s for
  how they should work in the future.
  

- **Clarity: `parse_deck()` helper in syntax_test.py.**
  