### PR TITLE
Add `group:` and allow multiline config directives

### DIFF
--- a/asl/lesson-09.deck
+++ b/asl/lesson-09.deck
@@ -21,94 +21,85 @@ https://www.youtube.com/watch?v=ZcJGws8g8uE COUCH
   trim: 14F-87F
   more: +rst:`COUCH <https://www.lifeprint.com/asl101/pages-signs/c/couch.htm>`_
 
-https://www.youtube.com/watch?v=xzIU5tmBrLc
-  DOOR / cupboard / closet / cabinet / locker
-  trim: 11F-77F
+group:
   more: +rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
-https://www.youtube.com/watch?v=SDTlfgtJKlI OPEN-DOOR
-  trim: 17F-85F
-  more: +rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
-https://www.youtube.com/watch?v=kCiFi6IQpBE CLOSE-DOOR
-  trim: 14F-79F
-  more: +rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
-https://www.youtube.com/watch?v=LEWPXaskrJk OPEN
-  trim: 22F-77F
-  more: +rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
-https://www.youtube.com/watch?v=adXm1AhwMBM CLOSE / CLOSED
-  trim: 25F-85F
-  more: +rst:`DOOR <https://www.lifeprint.com/asl101/pages-signs/d/door.htm>`_
+
+  https://www.youtube.com/watch?v=xzIU5tmBrLc
+    DOOR / cupboard / closet / cabinet / locker
+    trim: 11F-77F
+  https://www.youtube.com/watch?v=SDTlfgtJKlI OPEN-DOOR
+    trim: 17F-85F
+  https://www.youtube.com/watch?v=kCiFi6IQpBE CLOSE-DOOR
+    trim: 14F-79F
+  https://www.youtube.com/watch?v=LEWPXaskrJk OPEN
+    trim: 22F-77F
+  https://www.youtube.com/watch?v=adXm1AhwMBM CLOSE / CLOSED
+    trim: 25F-85F
 
 https://www.youtube.com/watch?v=9G23AjmjyV4 DRESSER / DRAWER
   trim: 13F-76F
   more: +rst:`DRESSER <https://www.lifeprint.com/asl101/pages-signs/d/dresser.htm>`_
 
-https://www.youtube.com/watch?v=NuXm0_3x6n8 DRY
-  trim: 9F-64F
+group:
   more: +rst:`DRYER <https://www.lifeprint.com/asl101/pages-signs/d/dryer.htm>`_
-https://www.youtube.com/watch?v=OF3KatN3TgU DRYER-[DRY-DRY-version]
-  trim: 11F-54F
-  more: +rst:`DRYER <https://www.lifeprint.com/asl101/pages-signs/d/dryer.htm>`_
-https://www.youtube.com/watch?v=HsCGIr9TDbE DRYER-[DRY-spin-around-version]
-  trim: 8F-72F
-  more: +rst:`DRYER <https://www.lifeprint.com/asl101/pages-signs/d/dryer.htm>`_
+
+  https://www.youtube.com/watch?v=NuXm0_3x6n8 DRY
+    trim: 9F-64F
+  https://www.youtube.com/watch?v=OF3KatN3TgU DRYER-[DRY-DRY-version]
+    trim: 11F-54F
+  https://www.youtube.com/watch?v=HsCGIr9TDbE DRYER-[DRY-spin-around-version]
+    trim: 8F-72F
 
 https://www.youtube.com/watch?v=6i1516QNfaY GARAGE
   trim: 15F-
   more: +rst:`GARAGE <https://www.lifeprint.com/asl101/pages-signs/g/garage.htm>`_
 
-# I’m unsure about my interpretation of THROW-OUT and THROW-AWAY
-https://www.youtube.com/watch?v=sHFqJ68Ev8o GARBAGE / trash
-  trim: 4F-
-  more: +rst:`GARBAGE <https://www.lifeprint.com/asl101/pages-signs/g/garbage.htm>`_
-https://www.youtube.com/watch?v=TCopmoEfXaw THROW-AWAY (small variant)
-  trim: 14F-44F
-  more: +rst:`GARBAGE <https://www.lifeprint.com/asl101/pages-signs/g/garbage.htm>`_
-https://www.youtube.com/watch?v=TnWogCQKnXQ THROW-OUT (big variant)
-  trim: 9F-74F
+group:
   more: +rst:`GARBAGE <https://www.lifeprint.com/asl101/pages-signs/g/garbage.htm>`_
 
-https://www.youtube.com/watch?v=-yEO1YL7dSg KITCHEN (“cook” variation)
-  trim: 15F-79F
-  more: +rst:`KITCHEN <https://www.lifeprint.com/asl101/pages-signs/k/kitchen.htm>`_
-https://www.youtube.com/watch?v=u6KL0UFbL5M KITCHEN (one-handed variation)
-  trim: 6F-64F
-  more: +rst:`KITCHEN <https://www.lifeprint.com/asl101/pages-signs/k/kitchen.htm>`_
-https://www.youtube.com/watch?v=Xy0FCuz1KHw COOK / KITCHEN
-  trim: 12F-70F
+  # I’m unsure about my interpretation of THROW-OUT and THROW-AWAY
+  https://www.youtube.com/watch?v=sHFqJ68Ev8o GARBAGE / trash
+    trim: 4F-
+  https://www.youtube.com/watch?v=TCopmoEfXaw THROW-AWAY (small variant)
+    trim: 14F-44F
+  https://www.youtube.com/watch?v=TnWogCQKnXQ THROW-OUT (big variant)
+    trim: 9F-74F
+
+group:
   more: +rst:`KITCHEN <https://www.lifeprint.com/asl101/pages-signs/k/kitchen.htm>`_
 
-# LIGHTS / LIGHTS-ON is in lesson 8
-https://www.youtube.com/watch?v=u33E8wPkfyU LIGHTS-FLASH
-  trim: 11F-57F
-  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
-https://www.youtube.com/watch?v=aCIocBQ6ylU
-  LIGHT-device / LIGHT-bulb / LIGHT (general)
-  trim: 9F-102F
-  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
-https://www.youtube.com/watch?v=uKSJnAaaXBE BRIGHT / CLEAR / OBVIOUS
-  trim: 10F-71F
+  https://www.youtube.com/watch?v=-yEO1YL7dSg KITCHEN (“cook” variation)
+    trim: 15F-79F
+  https://www.youtube.com/watch?v=u6KL0UFbL5M KITCHEN (one-handed variation)
+    trim: 6F-64F
+  https://www.youtube.com/watch?v=Xy0FCuz1KHw COOK / KITCHEN
+    trim: 12F-70F
+
+group:
   more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
 
-tags: +extra
-https://www.youtube.com/watch?v=fnYd3XHdEPI RAY-of-light / SUN-ray
-  trim: 28F-78F
-  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
-https://www.youtube.com/watch?v=KOKG7jy8Loo LAMP
-  trim: 13F-70F
-  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
-https://www.youtube.com/watch?v=dTjopMLqGIQ HEADLIGHTS
-  trim: 37F-88F
-  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
-https://www.youtube.com/watch?v=C37R_Ix8-qs LIGHT-A-MATCH
-  trim: 11F-72F
-  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
-https://www.youtube.com/watch?v=lnbXEMxYdn4 AMBULANCE / LIGHTS-rotating-flashing
-  trim: 13F-86F
-  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
-https://www.youtube.com/watch?v=_zgfuzlhI9Q LIGHT-WEIGHT
-  trim: 25F-92F
-  more: +rst:`LIGHT <https://www.lifeprint.com/asl101/pages-signs/l/light.htm>`_
-tags: -extra
+  # LIGHTS / LIGHTS-ON is in lesson 8
+  https://www.youtube.com/watch?v=u33E8wPkfyU LIGHTS-FLASH
+    trim: 11F-57F
+  https://www.youtube.com/watch?v=aCIocBQ6ylU
+    LIGHT-device / LIGHT-bulb / LIGHT (general)
+    trim: 9F-102F
+  https://www.youtube.com/watch?v=uKSJnAaaXBE BRIGHT / CLEAR / OBVIOUS
+    trim: 10F-71F
+
+  tags: +extra
+  https://www.youtube.com/watch?v=fnYd3XHdEPI RAY-of-light / SUN-ray
+    trim: 28F-78F
+  https://www.youtube.com/watch?v=KOKG7jy8Loo LAMP
+    trim: 13F-70F
+  https://www.youtube.com/watch?v=dTjopMLqGIQ HEADLIGHTS
+    trim: 37F-88F
+  https://www.youtube.com/watch?v=C37R_Ix8-qs LIGHT-A-MATCH
+    trim: 11F-72F
+  https://www.youtube.com/watch?v=lnbXEMxYdn4 AMBULANCE / LIGHTS-rotating-flashing
+    trim: 13F-86F
+  https://www.youtube.com/watch?v=_zgfuzlhI9Q LIGHT-WEIGHT
+    trim: 25F-92F
 
 https://www.youtube.com/watch?v=kzvEJrS357s MICROWAVE
   trim: 9F-57F
@@ -127,55 +118,53 @@ https://www.youtube.com/watch?v=iJ8TFRWJutE SHOWER
   trim: 11F-58F
   more: +rst:`SHOWER <https://www.lifeprint.com/asl101/pages-signs/s/shower.htm>`_
 
-https://www.youtube.com/watch?v=iZJAZYXj-Gw #SINK
-  trim: 11F-61F
+group:
   more: +rst:`SINK <https://www.lifeprint.com/asl101/pages-signs/s/sink.htm>`_
 
-tags: +extra
-https://www.youtube.com/watch?v=fwnMkFs7sdc SINK (depictive version)
-  trim: 4F-
-  more: +rst:`SINK <https://www.lifeprint.com/asl101/pages-signs/s/sink.htm>`_
-https://www.youtube.com/watch?v=TIi1dumlqjE SINK (verb) / to become submerged
-  trim: 8F-58F
-  more: +rst:`SINK <https://www.lifeprint.com/asl101/pages-signs/s/sink.htm>`_
-tags: -extra
+  https://www.youtube.com/watch?v=iZJAZYXj-Gw #SINK
+    trim: 11F-61F
 
-https://www.youtube.com/watch?v=c75leThE9AQ #STOVE
-  trim: 11F-62F
+  tags: +extra
+  https://www.youtube.com/watch?v=fwnMkFs7sdc SINK (depictive version)
+    trim: 4F-
+  https://www.youtube.com/watch?v=TIi1dumlqjE SINK (verb) / to become submerged
+    trim: 8F-58F
+
+group:
   more: +rst:`STOVE <https://www.lifeprint.com/asl101/pages-signs/s/stove.htm>`_
 
-tags: +extra
-https://www.youtube.com/watch?v=3_2Zyn10sZI #OVEN
-  trim: 22F-86F
-  more: +rst:`STOVE <https://www.lifeprint.com/asl101/pages-signs/s/stove.htm>`_
-https://www.youtube.com/watch?v=bf1X67Lhu6A OVEN / BAKING
-  more: +rst:`STOVE <https://www.lifeprint.com/asl101/pages-signs/s/stove.htm>`_
-https://www.youtube.com/watch?v=Q0vD9t1u5bI BAKE
-  trim: 14F-67F
-  more: +rst:`STOVE <https://www.lifeprint.com/asl101/pages-signs/s/stove.htm>`_
-tags: -extra
+  https://www.youtube.com/watch?v=c75leThE9AQ #STOVE
+    trim: 11F-62F
+
+  tags: +extra
+  https://www.youtube.com/watch?v=3_2Zyn10sZI #OVEN
+    trim: 22F-86F
+  https://www.youtube.com/watch?v=bf1X67Lhu6A OVEN / BAKING
+  https://www.youtube.com/watch?v=Q0vD9t1u5bI BAKE
+    trim: 14F-67F
 
 https://www.youtube.com/watch?v=UJINxF1cSUA TABLE / DESK
   trim: 11F-73F
   more: +rst:`TABLE <https://www.lifeprint.com/asl101/pages-signs/t/table.htm>`_
 
-https://www.youtube.com/watch?v=VqFX50Z9Y60 WINDOW
-  trim: 10F-75F
-  more: +rst:`WINDOW <https://www.lifeprint.com/asl101/pages-signs/w/window.htm>`_
-https://www.youtube.com/watch?v=C_e84lDOEoU OPEN-WINDOW
-  trim: 10F-69F
-  more: +rst:`WINDOW <https://www.lifeprint.com/asl101/pages-signs/w/window.htm>`_
-https://www.youtube.com/watch?v=a5IIsvDsjcQ CLOSE-WINDOW
-  trim: 10F-72F
+group:
   more: +rst:`WINDOW <https://www.lifeprint.com/asl101/pages-signs/w/window.htm>`_
 
-https://www.youtube.com/watch?v=BrSb83b9kbY YESTERDAY
-  trim: 13F-72F
+  https://www.youtube.com/watch?v=VqFX50Z9Y60 WINDOW
+    trim: 10F-75F
+  https://www.youtube.com/watch?v=C_e84lDOEoU OPEN-WINDOW
+    trim: 10F-69F
+  https://www.youtube.com/watch?v=a5IIsvDsjcQ CLOSE-WINDOW
+    trim: 10F-72F
+
+group:
   more: +rst:`YESTERDAY <https://www.lifeprint.com/asl101/pages-signs/y/yesterday.htm>`_
-https://www.youtube.com/watch?v=WaIrad_avQI -> YESTERDAY (initialized)
-  trim: 30F-89F
-  more: +rst:`YESTERDAY <https://www.lifeprint.com/asl101/pages-signs/y/yesterday.htm>`_
-  tags: +extra
+
+  https://www.youtube.com/watch?v=BrSb83b9kbY YESTERDAY
+    trim: 13F-72F
+  https://www.youtube.com/watch?v=WaIrad_avQI -> YESTERDAY (initialized)
+    trim: 30F-89F
+    tags: +extra
 
 # SAY is in lesson 5 extra
 https://www.youtube.com/watch?v=-Dv4nnY_F18 what-SAY / What was said?
@@ -187,52 +176,48 @@ https://www.youtube.com/watch?v=6IXVVDel4lw TOOTHPASTE
   trim: 13F-74F
   more: +rst:`TOOTHPASTE <https://www.lifeprint.com/asl101/pages-signs/t/toothpaste.htm>`_
 
-https://www.youtube.com/watch?v=7Z1WMbq2Y6E AHEAD
-  trim: 9F-77F
+
+group:
   more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
-https://www.youtube.com/watch?v=VoetY5cF1Oo BEHIND
-  trim: 8F-67F
-  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
-https://www.youtube.com/watch?v=l2fU_9FofrE FALL-BEHIND
-  trim: 10F-69F
-  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
-https://www.youtube.com/watch?v=ESOxu86BLGw AVOID
-  trim: 57F-116F
-  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
-https://www.youtube.com/watch?v=6ywnNz3BaMk FOLLOW / following / obey
-  trim: 4F-53F
-  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
-https://www.youtube.com/watch?v=P0g3SiRW__4 CATCH-UP
-  trim: 6F-65F
-  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
-https://www.youtube.com/watch?v=PNp3dIAoFGA CHASE
-  trim: 11F-69F
-  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
-https://www.youtube.com/watch?v=H37s1WoEGEs RACE / COMPETE
-  trim: 7F-68F
-  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
-https://www.youtube.com/watch?v=Esuc74eXfMA UNDER / SUBORDINATE
-  trim: 16F-75F
-  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
-https://www.youtube.com/watch?v=jQC2QdxW9u0 ABOVE / SUPERIOR
-  trim: 16F-88F
-  more: +rst:`WITH (advanced) <https://www.lifeprint.com/asl101/pages-signs/w/withadvanced.htm>`_
+
+  https://www.youtube.com/watch?v=7Z1WMbq2Y6E AHEAD
+    trim: 9F-77F
+  https://www.youtube.com/watch?v=VoetY5cF1Oo BEHIND
+    trim: 8F-67F
+  https://www.youtube.com/watch?v=l2fU_9FofrE FALL-BEHIND
+    trim: 10F-69F
+  https://www.youtube.com/watch?v=ESOxu86BLGw AVOID
+    trim: 57F-116F
+  https://www.youtube.com/watch?v=6ywnNz3BaMk FOLLOW / following / obey
+    trim: 4F-53F
+  https://www.youtube.com/watch?v=P0g3SiRW__4 CATCH-UP
+    trim: 6F-65F
+  https://www.youtube.com/watch?v=PNp3dIAoFGA CHASE
+    trim: 11F-69F
+  https://www.youtube.com/watch?v=H37s1WoEGEs RACE / COMPETE
+    trim: 7F-68F
+  https://www.youtube.com/watch?v=Esuc74eXfMA UNDER / SUBORDINATE
+    trim: 16F-75F
+  https://www.youtube.com/watch?v=jQC2QdxW9u0 ABOVE / SUPERIOR
+    trim: 16F-88F
 
 # From video
-tags: +extra
-https://www.youtube.com/watch?v=DyYb5Y2efP4 APARTMENT
-  trim: 8F-72F
-  more: +html:<h1>#APT</h1>
-  more: +rst:`APARTMENT <https://www.lifeprint.com/asl101/pages-signs/a/apartment.htm>`_
+group:
+  tags: +extra
 
-https://www.youtube.com/watch?v=G4HZ1OaQHpI THAT (non-specific, one handed)
-  trim: 4F-56F
-  more: +rst:`THAT <https://www.lifeprint.com/asl101/pages-signs/t/that.htm>`_
-https://www.youtube.com/watch?v=tNas8PN6pIQ THAT (specific, Y-hand)
-  trim: 12F-51F
-  more: +rst:`THAT <https://www.lifeprint.com/asl101/pages-signs/t/that.htm>`_
-https://www.youtube.com/watch?v=IujovunU_X8 THAT (non-specific, two handed)
-  trim: 0-60F
-  more: +rst:`THAT <https://www.lifeprint.com/asl101/pages-signs/t/that.htm>`_
+  https://www.youtube.com/watch?v=DyYb5Y2efP4 APARTMENT
+    trim: 8F-72F
+    more: +html:<h1>#APT</h1>
+    more: +rst:`APARTMENT <https://www.lifeprint.com/asl101/pages-signs/a/apartment.htm>`_
 
-# Couldn’t find video for [natural]-GAS or G-A-S.
+  group:
+    more: +rst:`THAT <https://www.lifeprint.com/asl101/pages-signs/t/that.htm>`_
+
+    https://www.youtube.com/watch?v=G4HZ1OaQHpI THAT (non-specific, one handed)
+      trim: 4F-56F
+    https://www.youtube.com/watch?v=tNas8PN6pIQ THAT (specific, Y-hand)
+      trim: 12F-51F
+    https://www.youtube.com/watch?v=IujovunU_X8 THAT (non-specific, two handed)
+      trim: 0-60F
+
+  # Couldn’t find video for [natural]-GAS or G-A-S.

--- a/asl/numbers-31-100.deck
+++ b/asl/numbers-31-100.deck
@@ -82,8 +82,8 @@ https://www.youtube.com/watch?v=M4AFC4eEjlQ @4794F-4826F 92
 https://www.youtube.com/watch?v=M4AFC4eEjlQ @4848F-4881F 93
 https://www.youtube.com/watch?v=M4AFC4eEjlQ @4902F-4938F 94
 https://www.youtube.com/watch?v=M4AFC4eEjlQ @4952F-4986F 95
+# 0-1F doesn’t slow the first frame (issue #16):
 https://www.youtube.com/watch?v=M4AFC4eEjlQ @5005F-5034F 96
-# 0-1F doesn’t slow the first frame (issue #16).
   slow: 0-2F *10
 https://www.youtube.com/watch?v=M4AFC4eEjlQ @5049F-5089F 97
 https://www.youtube.com/watch?v=M4AFC4eEjlQ @5103F-5140F 98

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ yanki = "yanki.cli:main"
 
 [tool.pytest.ini_options]
 script_launch_mode = "subprocess"
+log_cli_level = "DEBUG"
 
 [tool.ruff]
 line-length = 80

--- a/test-decks/errors/bad-indent.deck
+++ b/test-decks/errors/bad-indent.deck
@@ -1,4 +1,4 @@
-# Error in test-decks/errors/bad-indent.deck, line 2: Found indented line with no preceding unindented line
+# Error in test-decks/errors/bad-indent.deck, line 2: Unexpected indent
   test
 
 title: Test deck::Errors::Bad indent

--- a/test-decks/errors/no-title.deck
+++ b/test-decks/errors/no-title.deck
@@ -1,2 +1,2 @@
-# Error in test-decks/errors/no-title.deck, line 1: Does not contain title
+# Error in test-decks/errors/no-title.deck, line 0: Does not contain title
 file://../good/media/hand-counting.mp4 Hand counting

--- a/yanki/parser.py
+++ b/yanki/parser.py
@@ -4,12 +4,18 @@ from dataclasses import field
 import functools
 import inspect
 import io
+import logging
 import re
 import types
 import typing
 
 from yanki.errors import ExpectedError
 from yanki.field import Fragment, Field
+from yanki.utils import add_trace_logging
+
+add_trace_logging()
+LOGGER = logging.getLogger(__name__)
+
 
 # Valid variables in note_id format. Used to validate that our code uses the
 # same variables in both places they’re needed.
@@ -37,10 +43,7 @@ CONFIG_REGEX = re.compile(
     # The value must be separated from the colon by whitespace, but if there is
     # no value then whitespace is not required. (Consider a file that ends with
     # a config directive and then no newline.)
-    (?:\s+(\S.*))?
-
-    # Trailing whitespace including newlines.
-    \s*
+    (?:\s+(\S.*\s*)?)?
     """,
     flags=re.IGNORECASE | re.VERBOSE,
 )
@@ -324,63 +327,261 @@ class DeckSpec:
     def __init__(self, source_path):
         self.title = None
         self.source_path = source_path
-        self.config = NoteConfig()
         self.note_specs = []
+        # For debugging only:
+        self.config = None
 
     def add_note_spec(self, note_spec: NoteSpec):
         self.note_specs.append(note_spec)
 
 
+class Scope:
+    def __init__(self, line_number, deck, config):
+        self.start_line_number = line_number
+        self.current_line_number = line_number
+        self.deck = deck
+        self.config = config
+        self.indent = None
+        self.child_scope = None
+        self.trace("Opening")
+
+    def check_child_scope(self, indent, line):
+        if self.child_scope:
+            if self.child_scope.parse_line(
+                self.current_line_number, indent, line
+            ):
+                return True
+            self.child_scope = None
+        return False
+
+    def parse_line(self, line_number, indent, line):
+        self.current_line_number = line_number
+        self.trace(f"parse_line({indent!r}, {line!r})")
+
+        if line.strip("\n\r") == "":
+            # Blank line; indent might be wrong entirely so ignore it.
+            if self.check_child_scope(indent, line):
+                return True
+        elif self.indent is None:
+            self.indent = indent
+        elif len(indent) > len(self.indent):
+            if not indent.startswith(self.indent):
+                self.line_error("Mismatched indent")
+
+            if self.check_child_scope(indent, line):
+                return True
+
+            self.unexpected_indent()
+            # Add extra indent back to line.
+            line = indent.removeprefix(self.indent) + line
+        elif len(indent) < len(self.indent):
+            # Smaller indent; end of this scope. Any mismatched indent will be
+            # caught in the outer scope.
+            self.close()
+            return False
+        elif self.indent != indent:
+            self.line_error("Mismatched indent")
+        elif self.child_scope:
+            # Indent the same, so close any child scope.
+            self.child_scope.close()
+            self.child_scope = None
+
+        self.parse_unindented(line)
+        return True
+
+    def unexpected_indent(self):
+        self.line_error("Unexpected indent")
+
+    def close(self):
+        if self.child_scope:
+            self.child_scope.close()
+            self.child_scope = None
+        self.trace("Closing")
+
+    def parse_unindented(self, line):
+        if matches := CONFIG_REGEX.fullmatch(line):
+            self.parse_config(matches[1], matches[2] or "")
+        else:
+            self.parse_text(line)
+
+    def parse_config(self, directive, rest):
+        if directive == "group":
+            if rest.strip():
+                self.line_error(
+                    "Unexpected value after 'group:': {rest.strip()!r}"
+                )
+            self.child_scope = GroupScope(self)
+        else:
+            self.child_scope = ConfigScope(self, directive, rest)
+
+    def parse_text(self, line):
+        if line.startswith("#") or line.strip() == "":
+            # Comment or blank line; ignore.
+            return
+        self.child_scope = NoteScope(self, line)
+
+    def trace(self, message):
+        LOGGER.trace(
+            f"{self.logging_id()} at line {self.current_line_number}: {message}"
+        )
+
+    def logging_id(self):
+        return self.__class__.__name__
+
+    def scope_error(self, error):
+        """Raise a syntax error located at the start of the scope."""
+        raise DeckSyntaxError(
+            str(error),
+            self.deck.source_path,
+            self.start_line_number,
+        )
+
+    def line_error(self, error):
+        """Raise a syntax error located at the current line."""
+        raise DeckSyntaxError(
+            str(error),
+            self.deck.source_path,
+            self.current_line_number,
+        )
+
+
+class DeckScope(Scope):
+    # Supports notes, config, groups, "title:"
+    def __init__(self, deck):
+        super().__init__(0, deck, NoteConfig())
+        self.indent = ""
+
+    def finish(self):
+        """Close out inner scopes and return the finished deck."""
+        self.close()
+        if self.deck.title is None:
+            self.scope_error("Does not contain title")
+        self.deck.config = self.config
+        return self.deck
+
+    def logging_id(self):
+        return f"{self.__class__.__name__}[{self.deck.source_path!r}]"
+
+
+class SubScope(Scope):
+    def __init__(self, parent):
+        super().__init__(parent.current_line_number, parent.deck, parent.config)
+
+
+class GroupScope(SubScope):
+    # Supports notes, config, groups
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.config = deepcopy(self.config)
+
+    def parse_config(self, directive, rest):
+        if directive == "title":
+            self.line_error("Title cannot be set within group")
+        super().parse_config(directive, rest)
+
+
+class NoteScope(SubScope):
+    # Supports text, config
+    def __init__(self, parent, line):
+        self.text = [line]
+        super().__init__(parent)
+        self.config = deepcopy(self.config)
+
+    def unexpected_indent(self):
+        pass
+
+    def close(self):
+        super().close()
+        self.deck.add_note_spec(
+            NoteSpec(
+                config=self.config.frozen(),
+                source_path=self.deck.source_path,
+                line_number=self.start_line_number,
+                source="".join(self.text),
+            )
+        )
+
+    def parse_config(self, directive, rest):
+        if directive == "title":
+            self.line_error("Title cannot be set within note")
+        if directive == "group":
+            self.line_error("Group cannot be started within note")
+        super().parse_config(directive, rest)
+
+    def parse_text(self, line):
+        # Quotes can be used to prevent a line from being a config directive.
+        line_chomped = line.rstrip("\n\r")
+        if line.startswith('"') and line_chomped.endswith('"'):
+            # Stip quotes, but add the newline back:
+            line = line_chomped[1:-1] + line[len(line_chomped) :]
+
+        self.text.append(line)
+
+    def logging_id(self):
+        return f"{self.__class__.__name__}[{self.text[0]!r}]"
+
+
+class ConfigScope(SubScope):
+    # Supports text
+    def __init__(self, parent, directive, rest):
+        self.directive = directive
+        self.text = [rest]
+        super().__init__(parent)
+
+    def unexpected_indent(self):
+        pass
+
+    def parse_unindented(self, line):
+        # Don’t even look for config directives.
+        self.text.append(line)
+
+    def parse_config(self, directive, rest):
+        raise RuntimeError(
+            "parse_config() should be unreachable in ConfigScope"
+        )
+
+    def close(self):
+        super().close()
+        value = "".join(self.text).strip()
+        self.trace(f"Trying to set {value!r}")
+
+        if self.directive == "title":
+            # We prevent the ConfigScope from being created with this directive
+            # in all scopes except DeckScope.
+            if "\n" in value:
+                self.scope_error("Title cannot have more than one line")
+            self.deck.title = value
+            return
+
+        try:
+            self.config.set(self.directive, value)
+        except ValueError as error:
+            self.scope_error(error)
+
+    def logging_id(self):
+        return f"{self.__class__.__name__}[{self.directive!r}]"
+
+
 class DeckParser:
     def __init__(self):
         self.finished_decks = []
-        self._reset()
-
-    def _reset(self):
-        """Reset working deck data."""
-        self.working_deck = None
-        self.line_number = 0
-        self._reset_note()
-
-    def _reset_note(self):
-        """Reset working note data."""
-        self.note_source = []
-        self.note_config = None
-        self.note_line_number = None
+        self.scope = None
 
     def open(self, path):
         """Open a deck file for parsing."""
-        if self.working_deck:
-            self.close()
-        self._reset()
-        self.working_deck = DeckSpec(path)
+        self.close()
+        self.scope = DeckScope(DeckSpec(path))
 
     def close(self):
-        """Close deck file and mark working deck finished."""
-        if len(self.note_source) > 0:
-            self._finish_note()
-
-        if self.working_deck.title is None:
-            raise DeckSyntaxError(
-                "Does not contain title",
-                self.working_deck.source_path,
-                1,
-            )
-        self.finished_decks.append(self.working_deck)
-
-        self._reset()
+        """Close deck file and mark deck finished."""
+        if self.scope:
+            self.finished_decks.append(self.scope.finish())
+        self.scope = None
 
     def flush_decks(self):
         finished_decks = self.finished_decks
         self.finished_decks = []
         return finished_decks
-
-    def error(self, message):
-        source_path = None
-        if self.working_deck is not None:
-            source_path = self.working_deck.source_path
-
-        raise DeckSyntaxError(message, source_path, self.line_number)
 
     def parse_file(self, file_name: str, file: io.TextIOBase):
         for line_number, line in enumerate(file, start=1):
@@ -404,80 +605,9 @@ class DeckParser:
         yield from self.flush_decks()
 
     def parse_line(self, path, line_number, line):
-        if not self.working_deck or self.working_deck.source_path != path:
+        if not self.scope or self.scope.deck.source_path != path:
             self.open(path)
 
-        self.line_number = line_number
-
-        if line.startswith("#"):
-            # Comment; skip line.
-            return
-
-        if line.strip() == "":
-            # Blank lines only count inside notes.
-            if len(self.note_source) > 0:
-                self.note_source.append(line)
-            return
-
         unindented = line.lstrip(" \t")
-        if line == unindented:
-            # Not indented; any previous note can be finished.
-            if len(self.note_source) > 0:
-                self._finish_note()
-
-            # Line must be a config line or the start of a note.
-            if matches := CONFIG_REGEX.fullmatch(line):
-                # Config line
-                self._parse_config(matches, self.working_deck.config)
-            else:
-                # Start of a note. We’ve already finished the previous note.
-                self.note_line_number = self.line_number
-                self.note_config = deepcopy(self.working_deck.config)
-                self.note_source.append(self._strip_quotes(line))
-        else:
-            # Line is indented and thus a continuation of a note
-            if len(self.note_source) == 0:
-                self.error(
-                    "Found indented line with no preceding unindented line"
-                )
-
-            if matches := CONFIG_REGEX.fullmatch(unindented):
-                # Config line
-                self._parse_config(matches, self.note_config)
-            else:
-                # Continuation of note
-                self.note_source.append(self._strip_quotes(unindented))
-
-    def _parse_config(self, matches, config):
-        # Only call this is CONFIG_REGEX matches.
-        directive = matches[1]
-        value = (matches[2] or "").strip()
-
-        if directive == "title":
-            self.working_deck.title = value
-        else:
-            try:
-                config.set(directive, value)
-            except ValueError as error:
-                self.error(error)
-
-    def _strip_quotes(self, line):
-        """Quotes prevent a line from being a config directive."""
-        line_chomped = line.rstrip("\n\r")
-        if line.startswith('"') and line_chomped.endswith('"'):
-            # Stip quotes, but add the newline back:
-            return line_chomped[1:-1] + line[len(line_chomped) :]
-
-        return line
-
-    def _finish_note(self):
-        assert self.note_config is not None
-        self.working_deck.add_note_spec(
-            NoteSpec(
-                config=self.note_config.frozen(),
-                source_path=self.working_deck.source_path,
-                line_number=self.note_line_number,
-                source="".join(self.note_source),
-            )
-        )
-        self._reset_note()
+        indent = line[0 : len(line) - len(unindented)]
+        assert self.scope.parse_line(line_number, indent, unindented)

--- a/yanki/utils.py
+++ b/yanki/utils.py
@@ -1,8 +1,21 @@
+import contextlib
+from functools import partial, partialmethod
+import logging
 import os
 from pathlib import Path
 import tempfile
 from urllib.parse import urlparse
-import contextlib
+
+
+def add_trace_logging():
+    try:
+        logging.TRACE
+    except AttributeError:
+        # From user DerWeh at https://stackoverflow.com/a/55276759/1043949
+        logging.TRACE = 5
+        logging.addLevelName(logging.TRACE, "TRACE")
+        logging.Logger.trace = partialmethod(logging.Logger.log, logging.TRACE)
+        logging.trace = partial(logging.log, logging.TRACE)
 
 
 class NotFileURL(ValueError):


### PR DESCRIPTION
- **Add `group:` and allow multiline config directives**
  This allows notes to be arbitrarily grouped so that config directives can be easily applied to only a subset of notes.
  
  This also enables config directives, e.g. `more:`, to have multiple lines of value.
  
- **ASL lesson 9: use `group:` syntax.**
  
- **ASL numbers deck: fix comment indent.**

### To do
* [x] Clean up parser code
* [x] More tests