### PR TITLE
Speed up `test-decks_test.py`

### DIFF
--- a/test-decks/errors/bad-crop.deck
+++ b/test-decks/errors/bad-crop.deck
@@ -1,4 +1,4 @@
-#ends: Error in ffmpeg. See above.
+# Error running ffmpeg
 title: Test deck::Errors::Bad crop
 crop: 100000:1
 

--- a/test-decks/errors/bad-crop.deck
+++ b/test-decks/errors/bad-crop.deck
@@ -2,4 +2,4 @@
 title: Test deck::Errors::Bad crop
 crop: 100000:1
 
-file://../good/media/hand-counting.mp4 bad crop
+file://../good/media/first.png bad crop

--- a/test-decks/errors/duplicate-note.deck
+++ b/test-decks/errors/duplicate-note.deck
@@ -2,5 +2,5 @@
 title: Test deck::Errors::Duplicate note
 note_id: foo
 
-file://../good/media/hand-counting.mp4 YES
-file://../good/media/hand-counting.mp4 YES2
+file://../good/media/first.png YES
+file://../good/media/first.png YES2

--- a/test-decks/errors/slow-too-fast.deck
+++ b/test-decks/errors/slow-too-fast.deck
@@ -1,6 +1,6 @@
 # Error in test-decks/errors/slow-too-fast.deck, line 5: Cannot slow by less than 0.01: 0-1 *0.001
 title: Test deck::Errors::Slow too fast
 
-file://../good/media/hand-counting.mp4 too fast
+file://../good/media/first.png too fast
   slow: 0-1 *0.001
 

--- a/test-decks/good/config.deck
+++ b/test-decks/good/config.deck
@@ -1,17 +1,17 @@
 title: Test deck::Config
 note_id: {deck_id} {text}
 
-file://./media/stopwatch.mp4 more: should not do anything
+file://./media/first.png more: should not do anything
   (testing config on same line as URL — should not apply config)
 
-file://./media/stopwatch.mp4 more: inside note
+file://./media/first.png more: inside note
   more: inside note
 
 more: deck config
 
-file://./media/stopwatch.mp4
+file://./media/first.png
   more: inside note (plus quoted)
   "more: inside note (plus quoted)"
 
-file://./media/stopwatch.mp4
+file://./media/first.png
   "more: deck config"

--- a/test-decks/good/slow.deck
+++ b/test-decks/good/slow.deck
@@ -1,8 +1,6 @@
 title: Test deck::Partial slow
 note_id: {deck_id} {text}
 
-file://./media/stopwatch.mp4 BASE
-
 file://./media/stopwatch.mp4
   slow: - * 0.1
   without trim: slow: - * 0.1
@@ -20,13 +18,3 @@ file://./media/stopwatch.mp4
 file://./media/stopwatch.mp4
   slow: 0.5- * 0.25
   with 1s-2s trim: slow: 0.5- * 0.25
-
-file://./media/stopwatch.mp4
-  video: strip
-  slow: 0.5- * 0.25
-  no video / with 1s-2s trim: slow: 0.5- * 0.25
-
-file://./media/stopwatch.mp4
-  audio: strip
-  slow: 0.5- * 0.25
-  no audio / with 1s-2s trim: slow: 0.5- * 0.25

--- a/test-decks/good/tags.deck
+++ b/test-decks/good/tags.deck
@@ -2,11 +2,11 @@ title: Test deck::Tags
 tags: test::a test::b
 note_id: {deck_id} {text}
 
-file://./media/stopwatch.mp4 Tags [test::a, test::c]
+file://./media/first.png Tags [test::a, test::c]
   tags: +test::c -test::b
 
-file://./media/stopwatch.mp4 Tags [test::a, test::b]
+file://./media/first.png Tags [test::a, test::b]
 
 # Remove tag that doesn’t exist
-file://./media/stopwatch.mp4 Tags []
+file://./media/first.png Tags []
   tags: -test::a -test::b -test::c


### PR DESCRIPTION
- **Faster parsing in `test-decks_test.py`**
  This switches back to parsing the decks in the same process rather than
  calling out to a subprocess. On my laptop, the test goes from a mean
  time of 11.0 seconds to 6.4 seconds.
  

- **Speed up decks in `test-decks`**
  Trim some excess notes in the decks, and switch media to still images
  where possible. This improves `test-decks_test.py` time from 6.4 seconds
  to 4.1 seconds.
  