### PR TITLE
Add `tags` to note variables

### DIFF
--- a/yanki/anki.py
+++ b/yanki/anki.py
@@ -174,6 +174,7 @@ class Note:
             ### versions of the input text?
             "media": f"{self.spec.video_url()} {self.clip_spec()}",
             "text": self.text(),
+            "tags": " ".join(sorted(self.spec.config.tags)),
             "line_number": self.spec.line_number,
             "source_path": self.spec.source_path,
         }
@@ -264,6 +265,7 @@ class FinalNote:
             ### versions of the input text?
             "media": f"{self.spec.video_url()} {self.clip_spec}",
             "text": self.text,
+            "tags": " ".join(sorted(self.spec.config.tags)),
             "line_number": self.spec.line_number,
             "source_path": self.spec.source_path,
             "media_paths": " ".join(self.media_paths()),

--- a/yanki/parser/config.py
+++ b/yanki/parser/config.py
@@ -16,6 +16,7 @@ NOTE_VARIABLES = frozenset(
         "direction",
         "media",
         "text",
+        "tags",
         "line_number",
         "source_path",
     ]

--- a/yanki/parser/model.py
+++ b/yanki/parser/model.py
@@ -21,6 +21,7 @@ class NoteSpec:
             direction=self.direction(),
             media=" ".join([self.video_url(), self.provisional_clip_spec()]),
             text=self.text(),
+            tags=" ".join(sorted(self.config.tags)),
             line_number=self.line_number,
             source_path=self.source_path,
         )


### PR DESCRIPTION
This allows using `list-notes` to figure out how many notes you have
that have a certain tag.
