### PR TITLE
Add more variables for `list-notes` and `note_id`

### DIFF
--- a/tests/note_test.py
+++ b/tests/note_test.py
@@ -1,0 +1,31 @@
+import asyncio
+from yanki.parser.config import NoteConfig, NOTE_VARIABLES
+from yanki.parser import NoteSpec
+from yanki.anki import Note, FINAL_NOTE_VARIABLES
+from yanki.video import VideoOptions
+
+
+def example_note_spec():
+    return NoteSpec(
+        source_path="-",
+        line_number=1,
+        source="file://test-decks/good/media/first.png text",
+        config=NoteConfig().frozen(),
+    )
+
+
+def example_note(cache_path):
+    return Note(example_note_spec(), VideoOptions(cache_path))
+
+
+def test_note_spec_variables():
+    assert set(example_note_spec().variables().keys()) == NOTE_VARIABLES
+
+
+def test_note_variables(cache_path):
+    assert set(example_note(cache_path).variables().keys()) == NOTE_VARIABLES
+
+
+def test_final_note_variables(cache_path):
+    note = asyncio.run(example_note(cache_path).finalize(deck_id=1))
+    assert set(note.variables().keys()) == FINAL_NOTE_VARIABLES

--- a/yanki/anki.py
+++ b/yanki/anki.py
@@ -165,29 +165,13 @@ class Note:
         )
 
     def variables(self, deck_id="{deck_id}"):
-        variables = {
+        return {
+            **self.spec.variables(),
             "deck_id": deck_id,
-            "url": self.spec.video_url(),
             "clip": self.clip_spec(),
-            "direction": self.spec.direction(),
-            ### FIXME should these be renamed to clarify that they’re normalized
-            ### versions of the input text?
             "media": f"{self.spec.video_url()} {self.clip_spec()}",
             "text": self.text(),
-            "tags": " ".join(sorted(self.spec.config.tags)),
-            "line_number": self.spec.line_number,
-            "source_path": self.spec.source_path,
         }
-
-        # FIXME: probably doesn’t need to run every time.
-        if NOTE_VARIABLES != set(variables.keys()):
-            raise KeyError(
-                "Note.variables() does not match NOTE_VARIABLES\n"
-                f"  variables(): {sorted(variables.keys())}\n"
-                f"  expected: {sorted(NOTE_VARIABLES)}\n"
-            )
-
-        return variables
 
     @functools.cache
     def clip_spec(self):
@@ -255,31 +239,15 @@ class FinalNote:
         return Field([self.media_fragment])
 
     def variables(self):
-        variables = {
+        return {
+            **self.spec.variables(),
             "deck_id": self.deck_id,
             "note_id": self.note_id,
-            "url": self.spec.video_url(),
             "clip": self.clip_spec,
-            "direction": self.spec.direction(),
-            ### FIXME should these be renamed to clarify that they’re normalized
-            ### versions of the input text?
             "media": f"{self.spec.video_url()} {self.clip_spec}",
             "text": self.text,
-            "tags": " ".join(sorted(self.spec.config.tags)),
-            "line_number": self.spec.line_number,
-            "source_path": self.spec.source_path,
             "media_paths": " ".join(self.media_paths()),
         }
-
-        # FIXME: probably doesn’t need to run every time.
-        if FINAL_NOTE_VARIABLES != set(variables.keys()):
-            raise KeyError(
-                "FinalNote.variables() does not match FINAL_NOTE_VARIABLES\n"
-                f"  variables(): {sorted(variables.keys())}\n"
-                f"  expected: {sorted(FINAL_NOTE_VARIABLES)}\n"
-            )
-
-        return variables
 
     def genanki_note(self):
         media_to_text = text_to_media = ""

--- a/yanki/parser/model.py
+++ b/yanki/parser/model.py
@@ -14,17 +14,22 @@ class NoteSpec:
 
     @functools.cache
     def provisional_note_id(self, deck_id="{deck_id}"):
-        return self.config.generate_note_id(
-            deck_id=deck_id,
-            url=self.video_url(),
-            clip=self.provisional_clip_spec(),
-            direction=self.direction(),
-            media=" ".join([self.video_url(), self.provisional_clip_spec()]),
-            text=self.text(),
-            tags=" ".join(sorted(self.config.tags)),
-            line_number=self.line_number,
-            source_path=self.source_path,
-        )
+        return self.config.generate_note_id(**self.variables(deck_id=deck_id))
+
+    @functools.cache
+    def variables(self, deck_id="{deck_id}"):
+        """Get variables related to this note, including config variables."""
+        return {
+            **self.config.variables(),
+            "deck_id": deck_id,
+            "url": self.video_url(),
+            "clip": self.provisional_clip_spec(),
+            "direction": self.direction(),
+            "media": " ".join([self.video_url(), self.provisional_clip_spec()]),
+            "text": self.text(),
+            "line_number": self.line_number,
+            "source_path": self.source_path,
+        }
 
     def video_url(self):
         return self._parse_video_url()[0]


### PR DESCRIPTION
This makes all the `NoteConfig` variables available in `list-notes` and
in the `note_id` format config directive. (Note that `title:` isn’t
actually part of `NoteConfig`.) It will be useful for querying things
like how many notes use `trim:` or `more:`.

This also moves validation that all of the variable names match
everywhere into tests.
