### PR TITLE
ASL decks: fix gloss for fingerspelled signs

### DIFF
--- a/asl/lesson-05.deck
+++ b/asl/lesson-05.deck
@@ -5,7 +5,7 @@ tags: lesson_05 vocabulary
 audio: strip
 note_id: Lifeprint ASL {url} {clip}
 
-https://www.youtube.com/watch?v=cBBmjJ80m30 #CAR
+https://www.youtube.com/watch?v=cBBmjJ80m30 C-A-R
 https://www.youtube.com/watch?v=BVypOVtFnNk CAN
 https://www.youtube.com/watch?v=YfwGL0ZIBqE CAR / DRIVE
   tags: +first_100_signs

--- a/asl/lesson-07.deck
+++ b/asl/lesson-07.deck
@@ -41,7 +41,7 @@ https://www.youtube.com/watch?v=8ZOUoDZkAoQ HUNGRY / WISH
   tags: +first_100_signs
 https://www.youtube.com/watch?v=quk_XoRtZWk MILK
   tags: +first_100_signs
-https://www.youtube.com/watch?v=XIZ2DrdEU3k #PIZZA
+https://www.youtube.com/watch?v=XIZ2DrdEU3k P-I-ZZ-A
   tags: +first_100_signs
 https://www.youtube.com/watch?v=JZeO2EXjxOE PIZZA (eating slice version)
 https://www.youtube.com/watch?v=_1GRsPk6s3w PIZZA (ZZA version)

--- a/asl/lesson-09.deck
+++ b/asl/lesson-09.deck
@@ -110,7 +110,7 @@ https://www.youtube.com/watch?v=AxUJzzak-z0 -> MICROWAVE (3 fingers version)
 
 https://www.youtube.com/watch?v=LOW8ZIaAJ-c REFRIGERATOR
   trim: 7F-67F
-  more: +html:<h1>#REF</h1>
+  more: +html:<h1>R-E-F</h1>
   more: +rst:`REFRIGERATOR <https://www.lifeprint.com/asl101/pages-signs/r/refrigerator.htm>`_
 # No video for REFRIGERATOR version with R-hands like COLD
 
@@ -121,7 +121,7 @@ https://www.youtube.com/watch?v=iJ8TFRWJutE SHOWER
 group:
   more: +rst:`SINK <https://www.lifeprint.com/asl101/pages-signs/s/sink.htm>`_
 
-  https://www.youtube.com/watch?v=iZJAZYXj-Gw #SINK
+  https://www.youtube.com/watch?v=iZJAZYXj-Gw S-I-N-K
     trim: 11F-61F
 
   tags: +extra
@@ -133,11 +133,11 @@ group:
 group:
   more: +rst:`STOVE <https://www.lifeprint.com/asl101/pages-signs/s/stove.htm>`_
 
-  https://www.youtube.com/watch?v=c75leThE9AQ #STOVE
+  https://www.youtube.com/watch?v=c75leThE9AQ S-T-O-V-E
     trim: 11F-62F
 
   tags: +extra
-  https://www.youtube.com/watch?v=3_2Zyn10sZI #OVEN
+  https://www.youtube.com/watch?v=3_2Zyn10sZI O-V-E-N
     trim: 22F-86F
   https://www.youtube.com/watch?v=bf1X67Lhu6A OVEN / BAKING
   https://www.youtube.com/watch?v=Q0vD9t1u5bI BAKE
@@ -207,7 +207,7 @@ group:
 
   https://www.youtube.com/watch?v=DyYb5Y2efP4 APARTMENT
     trim: 8F-72F
-    more: +html:<h1>#APT</h1>
+    more: +html:<h1>A-P-T</h1>
     more: +rst:`APARTMENT <https://www.lifeprint.com/asl101/pages-signs/a/apartment.htm>`_
 
   group:

--- a/asl/lesson-10.deck
+++ b/asl/lesson-10.deck
@@ -107,9 +107,9 @@ group:
   tags: +extra
   https://www.youtube.com/watch?v=OTaYxoigN2U pony / SMALL HORSE
     trim: 16F-81F
-  https://www.youtube.com/watch?v=nwvGqVXrHVk HORSE #FLY
+  https://www.youtube.com/watch?v=nwvGqVXrHVk HORSE F-L-Y
     trim: 16F-77F
-  https://www.youtube.com/watch?v=V0FI60wvzpo HORSE #TRAIL
+  https://www.youtube.com/watch?v=V0FI60wvzpo HORSE T-R-A-I-L
     trim: 15F-90F
 
 group:

--- a/asl/lesson-11.deck
+++ b/asl/lesson-11.deck
@@ -47,7 +47,7 @@ group:
 
   https://www.youtube.com/watch?v=l3pElzy2Png BUT / however / different
     trim: 10F-59F
-  https://www.youtube.com/watch?v=A-n2pjNaz-k #BUT
+  https://www.youtube.com/watch?v=A-n2pjNaz-k B-U-T
     trim: 13F-62F
   https://www.youtube.com/watch?v=EunD6JXshgY DIFFERENT
     trim: 16F-77F
@@ -133,7 +133,7 @@ group:
   more: +rst:`OR <https://www.lifeprint.com/asl101/pages-signs/o/or.htm>`_
 
   # OR (bodyshift) is covered in lesson 7.
-  https://www.youtube.com/watch?v=6cB9xVBOasE #OR
+  https://www.youtube.com/watch?v=6cB9xVBOasE O-R
     trim: 7F-49F
   https://www.youtube.com/watch?v=1a2K-NNgODY THEN / or
     trim: 1F-60F

--- a/asl/lesson-12.deck
+++ b/asl/lesson-12.deck
@@ -186,7 +186,7 @@ group:
 group:
   more: +rst:`what-DO? <https://www.lifeprint.com/asl101/pages-signs/d/do-do.htm>`_
 
-  https://www.youtube.com/watch?v=W9EH9XSSIu0 WHAT-DO
+  https://www.youtube.com/watch?v=W9EH9XSSIu0 WHAT-DO / #DO / DO-DO
     trim: 10F-58F
 
 # YESTERDAY is in lesson 9


### PR DESCRIPTION
I misunderstood the meaning of #, e.g. #ALL. [Dr. Bill writes][DO]:

> That "#" mark indicates that the sign is a "lexicalized
> fingerspelling" sign that morphed from fingerspelling to the extent that
> it looks more like a sign and no longer looks much like individualized
> fingerspelled letters.

I was using for everything that was fingerspelled. For example, the
gloss for oven would be O-V-E-N, not #OVEN.

[DO]: https://www.lifeprint.com/asl101/pages-signs/d/do.htm
