### PR TITLE
Prevent `yt_dlp` from outputting to stdout

### DIFF
--- a/yanki/cli.py
+++ b/yanki/cli.py
@@ -112,6 +112,7 @@ def cli(ctx, verbose, cache, reprocess, concurrency):
 
     ctx.obj = VideoOptions(
         cache_path=cache,
+        progress=verbose > 0,
         reprocess=reprocess,
         semaphore=asyncio.Semaphore(concurrency),
     )


### PR DESCRIPTION
This also prevents it from dsiplaying a progress bar unless `-v` is set at least once.

This prevents a problem where `summary.txt` had extra junk in it from yt_dlp, which sometimes led to sorting problems.

Fixes: #142 — yanki, and thus `generate-summary.sh`, outputs progress reports when downloading videos