### PR TITLE
ASL decks: rename “Lifeprint ASL::Phrases::Lesson…”

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ That will produce an `out.apkg` file.
 ### Example deck file
 
 ```text
-title: Lifeprint ASL::Phrases::Lesson 01
+title: Lifeprint ASL::Phrases::Phrases 01
 overlay_text: Phrase
 more: md:From [Lifeprint](https://www.lifeprint.com/)
   ASLU [lesson 1](https://www.lifeprint.com/asl101/lessons/lesson01.htm)

--- a/asl/lesson-01-phrases.deck
+++ b/asl/lesson-01-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 01 — Introduction
+title: Lifeprint ASL::Phrases::Phrases 01 — Introduction
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 1](https://www.lifeprint.com/asl101/lessons/lesson01.htm)
 overlay_text: Phrase

--- a/asl/lesson-02-phrases.deck
+++ b/asl/lesson-02-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 02 — Family
+title: Lifeprint ASL::Phrases::Phrases 02 — Family
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 2](https://www.lifeprint.com/asl101/lessons/lesson02.htm)
 overlay_text: Phrase

--- a/asl/lesson-03-phrases.deck
+++ b/asl/lesson-03-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 03 — Places
+title: Lifeprint ASL::Phrases::Phrases 03 — Places
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 3](https://www.lifeprint.com/asl101/lessons/lesson03.htm)
 overlay_text: Phrase

--- a/asl/lesson-04-phrases.deck
+++ b/asl/lesson-04-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 04 — Feelings
+title: Lifeprint ASL::Phrases::Phrases 04 — Feelings
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 4](https://www.lifeprint.com/asl101/lessons/lesson04.htm)
 overlay_text: Phrase

--- a/asl/lesson-05-phrases.deck
+++ b/asl/lesson-05-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 05 — Actions
+title: Lifeprint ASL::Phrases::Phrases 05 — Actions
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 5](https://www.lifeprint.com/asl101/lessons/lesson05.htm)
 overlay_text: Phrase

--- a/asl/lesson-06-phrases.deck
+++ b/asl/lesson-06-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 06 — Colors & Time
+title: Lifeprint ASL::Phrases::Phrases 06 — Colors & Time
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 6](https://www.lifeprint.com/asl101/lessons/lesson06.htm)
 overlay_text: Phrase

--- a/asl/lesson-07-phrases.deck
+++ b/asl/lesson-07-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 07 — Food
+title: Lifeprint ASL::Phrases::Phrases 07 — Food
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 7](https://www.lifeprint.com/asl101/lessons/lesson07.htm)
 overlay_text: Phrase

--- a/asl/lesson-08-phrases.deck
+++ b/asl/lesson-08-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 08 — Clothes
+title: Lifeprint ASL::Phrases::Phrases 08 — Clothes
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 8](https://www.lifeprint.com/asl101/lessons/lesson08.htm)
 overlay_text: Phrase

--- a/asl/lesson-09-phrases.deck
+++ b/asl/lesson-09-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 09 — Things
+title: Lifeprint ASL::Phrases::Phrases 09 — Things
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 9](https://www.lifeprint.com/asl101/lessons/lesson09.htm)
 overlay_text: Phrase

--- a/asl/lesson-10-phrases.deck
+++ b/asl/lesson-10-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 10 — Animals
+title: Lifeprint ASL::Phrases::Phrases 10 — Animals
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 10](https://www.lifeprint.com/asl101/lessons/lesson10.htm)
 overlay_text: Phrase

--- a/asl/lesson-11-phrases.deck
+++ b/asl/lesson-11-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 11 — Questions
+title: Lifeprint ASL::Phrases::Phrases 11 — Questions
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 11](https://www.lifeprint.com/asl101/lessons/lesson11.htm)
 overlay_text: Phrase

--- a/asl/lesson-12-phrases.deck
+++ b/asl/lesson-12-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 12 — Routines
+title: Lifeprint ASL::Phrases::Phrases 12 — Routines
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 12](https://www.lifeprint.com/asl101/lessons/lesson12.htm)
 overlay_text: Phrase

--- a/asl/lesson-13-phrases.deck
+++ b/asl/lesson-13-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 13 — School
+title: Lifeprint ASL::Phrases::Phrases 13 — School
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 13](https://www.lifeprint.com/asl101/lessons/lesson13.htm)
 overlay_text: Phrase

--- a/asl/lesson-14-phrases.deck
+++ b/asl/lesson-14-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 14 — Seasons
+title: Lifeprint ASL::Phrases::Phrases 14 — Seasons
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 14](https://www.lifeprint.com/asl101/lessons/lesson14.htm)
 overlay_text: Phrase

--- a/asl/lesson-15-phrases.deck
+++ b/asl/lesson-15-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 15 — Careers
+title: Lifeprint ASL::Phrases::Phrases 15 — Careers
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 15](https://www.lifeprint.com/asl101/lessons/lesson15.htm)
 overlay_text: Phrase

--- a/asl/lesson-16-phrases.deck
+++ b/asl/lesson-16-phrases.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Phrases::Lesson 16 — Activities
+title: Lifeprint ASL::Phrases::Phrases 16 — Activities
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 16](https://www.lifeprint.com/asl101/lessons/lesson16.htm)
 overlay_text: Phrase


### PR DESCRIPTION
Swap “Lesson” for “Phrases” in the name of the Lifeprint ASL phrases
decks. This is helpful if you move the decks around to make studying
only first lessons easier.
