### PR TITLE
ASL decks: rename Vocabulary deck group

### DIFF
--- a/asl/lesson-01.deck
+++ b/asl/lesson-01.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 01 — Introduction
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 01 — Introduction
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 1](https://www.lifeprint.com/asl101/lessons/lesson01.htm)
 tags: Lifeprint lesson_01 vocabulary

--- a/asl/lesson-02.deck
+++ b/asl/lesson-02.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 02 — Family
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 02 — Family
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 2](https://www.lifeprint.com/asl101/lessons/lesson02.htm)
 tags: Lifeprint lesson_02 vocabulary

--- a/asl/lesson-03.deck
+++ b/asl/lesson-03.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 03 — Places
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 03 — Places
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 3](https://www.lifeprint.com/asl101/lessons/lesson03.htm)
 tags: Lifeprint lesson_03 vocabulary

--- a/asl/lesson-04.deck
+++ b/asl/lesson-04.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 04 — Feelings
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 04 — Feelings
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 4](https://www.lifeprint.com/asl101/lessons/lesson04.htm)
 tags: Lifeprint lesson_04 vocabulary

--- a/asl/lesson-05.deck
+++ b/asl/lesson-05.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 05 — Actions
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 05 — Actions
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 5](https://www.lifeprint.com/asl101/lessons/lesson05.htm)
 tags: Lifeprint lesson_05 vocabulary

--- a/asl/lesson-06.deck
+++ b/asl/lesson-06.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 06 — Colors & Time
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 06 — Colors & Time
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 6](https://www.lifeprint.com/asl101/lessons/lesson06.htm)
 tags: Lifeprint lesson_06 vocabulary

--- a/asl/lesson-07.deck
+++ b/asl/lesson-07.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 07 — Food
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 07 — Food
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 7](https://www.lifeprint.com/asl101/lessons/lesson07.htm)
 tags: Lifeprint lesson_07 vocabulary

--- a/asl/lesson-08.deck
+++ b/asl/lesson-08.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 08 — Clothes
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 08 — Clothes
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 8](https://www.lifeprint.com/asl101/lessons/lesson08.htm)
 tags: Lifeprint lesson_08 vocabulary

--- a/asl/lesson-09.deck
+++ b/asl/lesson-09.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 09 — Things
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 09 — Things
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 9](https://www.lifeprint.com/asl101/lessons/lesson09.htm)
 tags: Lifeprint lesson_09 vocabulary

--- a/asl/lesson-10.deck
+++ b/asl/lesson-10.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 10 — Animals
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 10 — Animals
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 10](https://www.lifeprint.com/asl101/lessons/lesson10.htm)
 tags: Lifeprint lesson_10 vocabulary

--- a/asl/lesson-11.deck
+++ b/asl/lesson-11.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 11 — Questions
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 11 — Questions
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 11](https://www.lifeprint.com/asl101/lessons/lesson11.htm)
 tags: Lifeprint lesson_11 vocabulary

--- a/asl/lesson-12.deck
+++ b/asl/lesson-12.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 12 — Routines
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 12 — Routines
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 12](https://www.lifeprint.com/asl101/lessons/lesson12.htm)
 tags: Lifeprint lesson_12 vocabulary

--- a/asl/lesson-13.deck
+++ b/asl/lesson-13.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 13 — School
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 13 — School
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 13](https://www.lifeprint.com/asl101/lessons/lesson13.htm)
 tags: Lifeprint lesson_13 vocabulary

--- a/asl/lesson-14.deck
+++ b/asl/lesson-14.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 14 — Seasons
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 14 — Seasons
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 14](https://www.lifeprint.com/asl101/lessons/lesson14.htm)
 tags: Lifeprint lesson_14 vocabulary

--- a/asl/lesson-15.deck
+++ b/asl/lesson-15.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 15 — Careers
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 15 — Careers
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 15](https://www.lifeprint.com/asl101/lessons/lesson15.htm)
 tags: Lifeprint lesson_15 vocabulary

--- a/asl/lesson-16.deck
+++ b/asl/lesson-16.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 16 — Activities
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 16 — Activities
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 16](https://www.lifeprint.com/asl101/lessons/lesson16.htm)
 tags: Lifeprint lesson_16 vocabulary

--- a/asl/lesson-17.deck
+++ b/asl/lesson-17.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 17 — Eating
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 17 — Eating
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 17](https://www.lifeprint.com/asl101/lessons/lesson17.htm)
 tags: Lifeprint lesson_17 vocabulary

--- a/asl/lesson-18.deck
+++ b/asl/lesson-18.deck
@@ -1,4 +1,4 @@
-title: Lifeprint ASL::Vocabulary::Lesson 18 — Travel
+title: Lifeprint ASL::Lesson Vocabulary::Lesson 18 — Travel
 more: md:From [Lifeprint](https://www.lifeprint.com/) ASLU
   [lesson 18](https://www.lifeprint.com/asl101/lessons/lesson18.htm)
 tags: Lifeprint lesson_18 vocabulary


### PR DESCRIPTION
This renames the “Vocabulary” deck group to “Lesson Vocabulary”, which
causes it to sort before “Numbers” and “Phrases”.
