### PR TITLE
Support `version: 1` config for future compatibility.

### DIFF
--- a/tests/syntax_test.py
+++ b/tests/syntax_test.py
@@ -34,6 +34,7 @@ def test_group():
     deck = parse_deck_dedent(
         """
         title: a
+        version: 1
         overlay_text: deck
         file:///one outer1
         group:
@@ -239,6 +240,36 @@ def test_note_parametrized(note_lines, parsed_text):
         (
             "title: a\n\tmore title",
             "Error in -, line 1: Title cannot have more than one line",
+        ),
+        (
+            "version: 2",
+            "Error in -, line 1: This version of yanki only supports version 1 "
+            "deck files (found '2')",
+        ),
+        (
+            "version:",
+            "Error in -, line 1: This version of yanki only supports version 1 "
+            "deck files (found '')",
+        ),
+        (
+            "title: a\ngroup:\n  title: one",
+            "Error in -, line 3: Title cannot be set within group",
+        ),
+        (
+            "title: a\ngroup:\n  version: 1",
+            "Error in -, line 3: Version cannot be set within group",
+        ),
+        (
+            "title: a\nfile:///foo note\n  title: one",
+            "Error in -, line 3: Title cannot be set within note",
+        ),
+        (
+            "title: a\nfile:///foo note\n  version: 1",
+            "Error in -, line 3: Version cannot be set within note",
+        ),
+        (
+            "title: a\nfile:///foo note\n  group:\n    foobar",
+            "Error in -, line 3: Group cannot be started within note",
         ),
     ],
 )

--- a/yanki/parser/parser.py
+++ b/yanki/parser/parser.py
@@ -140,7 +140,7 @@ class Parser:
 
 
 class DeckParser(Parser):
-    # Supports notes, config, groups, "title:"
+    # Supports notes, config, groups, "title:", "version:"
     def __init__(self, deck):
         super().__init__(0, deck, NoteConfig())
         self.indent = ""
@@ -171,6 +171,8 @@ class GroupParser(SubParser):
     def parse_config(self, directive, rest):
         if directive == "title":
             self.line_error("Title cannot be set within group")
+        if directive == "version":
+            self.line_error("Version cannot be set within group")
         super().parse_config(directive, rest)
 
 
@@ -198,6 +200,8 @@ class NoteParser(SubParser):
     def parse_config(self, directive, rest):
         if directive == "title":
             self.line_error("Title cannot be set within note")
+        if directive == "version":
+            self.line_error("Version cannot be set within note")
         if directive == "group":
             self.line_error("Group cannot be started within note")
         super().parse_config(directive, rest)
@@ -245,6 +249,16 @@ class ConfigParser(SubParser):
             if "\n" in value:
                 self.parser_error("Title cannot have more than one line")
             self.deck.title = value
+            return
+
+        if self.directive == "version":
+            # We prevent the ConfigParser from being created with this directive
+            # in all parsers except DeckParser.
+            if value != "1":
+                self.parser_error(
+                    "This version of yanki only supports version 1 deck files "
+                    f"(found {value!r})"
+                )
             return
 
         try:


### PR DESCRIPTION
Fixes: #85 — Add `version:` config and fail if the value ≥ 2
