### PR TITLE
Minor fixes

### DIFF
--- a/yanki/anki.py
+++ b/yanki/anki.py
@@ -95,7 +95,7 @@ class Note:
         )
 
     async def finalize_async(self, deck_id):
-        video = self.video()
+        video = await self.video().finalize_async()
         media_path = await video.processed_video_async()
 
         if video.is_still() or video.output_ext() == "gif":
@@ -111,7 +111,6 @@ class Note:
             text=self.text(),
             spec=self.spec,
             clip_spec=self.clip_spec(),
-            video=await video.finalize_async(),
             logger=logging.getLogger(f"FinalNote[{note_id}]"),
         )
 
@@ -213,7 +212,6 @@ class FinalNote:
     text: str
     spec: NoteSpec
     clip_spec: str
-    video: Video
     logger: logging.Logger
 
     def media(self):

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -536,8 +536,6 @@ class Video:
     async def actual_crop_async(self):
         if self._crop == "auto":
             return (await self.more_info_async())["cropdetect"]
-        if self._crop == "none":
-            return None
         return self._crop
 
     async def parameters_async(self):

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -377,6 +377,7 @@ class Video:
         # accessed synchronously.
         await self.more_info_async()
         await self.processed_video_async()
+        return self
 
     def clip(self, start_spec, end_spec):
         start = self.time_to_seconds(start_spec, on_none=0)


### PR DESCRIPTION
- **Clean up `Note.finalize_async()`**
  Make it clear that the media fragments have finalized videos, and remove
  the unused `video` field from `FinalNote`.
  

- **`Video._crop` should never be `"none"`.**
  