### PR TITLE
Fix clip output in video parameters

### DIFF
--- a/yanki/video.py
+++ b/yanki/video.py
@@ -619,10 +619,10 @@ class Video:
             self._cached_parameters["slow"] = self._slow
 
         match await self.actual_clip_async():
-            case float(_time):
-                self._cached_parameters["snapshot"] = self._clip
-            case (_start, _end):
-                self._cached_parameters["clip"] = self._clip
+            case float(time):
+                self._cached_parameters["snapshot"] = time
+            case (start, end):
+                self._cached_parameters["clip"] = (start, end)
 
         return self._cached_parameters
 


### PR DESCRIPTION
This is a no-op in the current code base, but it would have broken with
`trim: auto`. The code to generate video parameters was checking if a
clip or snapshot was used, and then used the information from
`self._clip` directly rather than the generated clip information.
