### PR TITLE
`serve-http`: Remove `--run-seconds` option

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -69,9 +69,7 @@ def test_yanki_serve_http(yanki, deck_1_path):
     results = []
 
     def run_yanki_serve_http():
-        results.append(
-            yanki.run("serve-http", "--run-seconds", "5", deck_1_path)
-        )
+        results.append(yanki.run("serve-http", deck_1_path))
 
     httpd = threading.Thread(target=run_yanki_serve_http)
     httpd.start()


### PR DESCRIPTION
This is really not all that useful, and it adds a bunch of extra
complexity, so I’m deleting it.
