### PR TITLE
Miscellaneous clean ups and lints

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{py,rs}]
+[*.{py,rs,toml}]
 indent_size = 4
 
 [*.zsh]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,9 @@ repos:
       - id: name-tests-test
       - id: no-commit-to-branch
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.0
+    rev: v0.12.1
     hooks:
-      - id: ruff
+      - id: ruff-check
       - id: ruff-format
         args: ['--check']
   - repo: local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ select = ["E", "F", "I", "N", "PERF", "RUF"]
 
 # RUF001 – RUF003: I frequently use characters that trigger these lints like "’"
 # and "❯".
-ignore = ["RUF001", "RUF002", "RUF003", "RUF022"]
+ignore = ["RUF001", "RUF002", "RUF003"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["yanki"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ select = ["E", "F", "I", "N", "PERF", "RUF"]
 
 # RUF001 – RUF003: I frequently use characters that trigger these lints like "’"
 # and "❯".
-ignore = ["RUF001", "RUF002", "RUF003", "RUF009", "RUF015", "RUF022"]
+ignore = ["RUF001", "RUF002", "RUF003", "RUF015", "RUF022"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["yanki"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,19 +37,37 @@ line-length = 80
 docstring-code-format = true
 
 [tool.ruff.lint]
-# E: https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
-# F: https://docs.astral.sh/ruff/rules/#pyflakes-f
-# I: https://docs.astral.sh/ruff/rules/#isort-i
-# N: https://docs.astral.sh/ruff/rules/#pep8-naming-n
-# PERF: https://docs.astral.sh/ruff/rules/#perflint-perf
-# RUF: https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
-# TRY: https://docs.astral.sh/ruff/rules/#tryceratops-try
-select = ["E", "F", "I", "N", "PERF", "RUF", "TRY"]
+select = [
+    # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+    "E",
+    # https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "F",
+    # https://docs.astral.sh/ruff/rules/#isort-i
+    "I",
+    # https://docs.astral.sh/ruff/rules/#pep8-naming-n
+    "N",
+    # https://docs.astral.sh/ruff/rules/#perflint-perf
+    "PERF",
+    # https://docs.astral.sh/ruff/rules/#pylint-pl
+    "PL",
+    # https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
+    "RUF",
+    # https://docs.astral.sh/ruff/rules/#tryceratops-try
+    "TRY",
+]
 
-# RUF001 – RUF003: I frequently use characters that trigger these lints like "’"
-# and "❯".
-# TRY003: It’s a lot more work to have separate error classes.
-ignore = ["RUF001", "RUF002", "RUF003", "TRY003"]
+ignore = [
+    # A lot of “magic” values are easier to understand without a CONSTANT.
+    "PLR2004",
+    # I like to shadow `for` loop variables.
+    "PLW2901",
+    # Ignore too many returns.
+    "PLR0911",
+    # I frequently use characters that trigger these lints like "’"  and "❯".
+    "RUF001", "RUF002", "RUF003",
+    # It’s a lot more work to have separate error classes.
+    "TRY003",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["yanki"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,10 @@ docstring-code-format = true
 # PERF: https://docs.astral.sh/ruff/rules/#perflint-perf
 # RUF: https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
 select = ["E", "F", "I", "N", "PERF", "RUF"]
-ignore = ["RUF001", "RUF003", "RUF005", "RUF009", "RUF015", "RUF022"]
+
+# RUF001 – RUF003: I frequently use characters that trigger these lints like "’"
+# and "❯".
+ignore = ["RUF001", "RUF002", "RUF003", "RUF005", "RUF009", "RUF015", "RUF022"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["yanki"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,13 @@ log_cli_level = "DEBUG"
 [tool.ruff]
 line-length = 80
 
+[tool.ruff.format]
+docstring-code-format = true
+
+[tool.ruff.lint]
+# I: isort
+extend-select = ["I"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["yanki"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ docstring-code-format = true
 # PERF: https://docs.astral.sh/ruff/rules/#perflint-perf
 # RUF: https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
 select = ["E", "F", "I", "N", "PERF", "RUF"]
-ignore = ["N818", "PERF401", "RUF001", "RUF003", "RUF005", "RUF009", "RUF015", "RUF022"]
+ignore = ["PERF401", "RUF001", "RUF003", "RUF005", "RUF009", "RUF015", "RUF022"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["yanki"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ select = ["E", "F", "I", "N", "PERF", "RUF"]
 
 # RUF001 – RUF003: I frequently use characters that trigger these lints like "’"
 # and "❯".
-ignore = ["RUF001", "RUF002", "RUF003", "RUF015", "RUF022"]
+ignore = ["RUF001", "RUF002", "RUF003", "RUF022"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["yanki"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ docstring-code-format = true
 # PERF: https://docs.astral.sh/ruff/rules/#perflint-perf
 # RUF: https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
 select = ["E", "F", "I", "N", "PERF", "RUF"]
-ignore = ["E501", "N818", "PERF401", "RUF001", "RUF003", "RUF005", "RUF009", "RUF015", "RUF022"]
+ignore = ["N818", "PERF401", "RUF001", "RUF003", "RUF005", "RUF009", "RUF015", "RUF022"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["yanki"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,8 @@ select = [
     "RUF",
     # https://docs.astral.sh/ruff/rules/#tryceratops-try
     "TRY",
+    # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "UP",
 ]
 
 ignore = [
@@ -73,6 +75,8 @@ ignore = [
     "RUF001", "RUF002", "RUF003",
     # It’s a lot more work to have separate error classes.
     "TRY003",
+    # I prefer to be explicit about opening files for reading.
+    "UP015",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ docstring-code-format = true
 # PERF: https://docs.astral.sh/ruff/rules/#perflint-perf
 # RUF: https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
 select = ["E", "F", "I", "N", "PERF", "RUF"]
-ignore = ["PERF401", "RUF001", "RUF003", "RUF005", "RUF009", "RUF015", "RUF022"]
+ignore = ["RUF001", "RUF003", "RUF005", "RUF009", "RUF015", "RUF022"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["yanki"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ authors = [{name = "Daniel Parks", email = "dp+git@oxidized.org"}]
 readme = "README.md"
 requires-python = ">= 3.11"
 dependencies = [
-  "yt-dlp >=2024.11.4",
-  "genanki >=0.13.1,<0.14",
-  "docutils >=0.21.2,<0.22",
-  "ffmpeg-python >=0.2.0,<0.3",
-  "colorlog >=6.9.0,<7.0",
-  "click >=8.1.8,<9.0",
-  "mistletoe>=1.4.0",
+    "yt-dlp >=2024.11.4",
+    "genanki >=0.13.1,<0.14",
+    "docutils >=0.21.2,<0.22",
+    "ffmpeg-python >=0.2.0,<0.3",
+    "colorlog >=6.9.0,<7.0",
+    "click >=8.1.8,<9.0",
+    "mistletoe>=1.4.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,13 @@ docstring-code-format = true
 # N: https://docs.astral.sh/ruff/rules/#pep8-naming-n
 # PERF: https://docs.astral.sh/ruff/rules/#perflint-perf
 # RUF: https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
-select = ["E", "F", "I", "N", "PERF", "RUF"]
+# TRY: https://docs.astral.sh/ruff/rules/#tryceratops-try
+select = ["E", "F", "I", "N", "PERF", "RUF", "TRY"]
 
 # RUF001 – RUF003: I frequently use characters that trigger these lints like "’"
 # and "❯".
-ignore = ["RUF001", "RUF002", "RUF003"]
+# TRY003: It’s a lot more work to have separate error classes.
+ignore = ["RUF001", "RUF002", "RUF003", "TRY003"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["yanki"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ select = ["E", "F", "I", "N", "PERF", "RUF"]
 
 # RUF001 – RUF003: I frequently use characters that trigger these lints like "’"
 # and "❯".
-ignore = ["RUF001", "RUF002", "RUF003", "RUF005", "RUF009", "RUF015", "RUF022"]
+ignore = ["RUF001", "RUF002", "RUF003", "RUF009", "RUF015", "RUF022"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["yanki"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ select = [
     "ERA",
     # https://docs.astral.sh/ruff/rules/#pyflakes-f
     "F",
+    # https://docs.astral.sh/ruff/rules/#refurb-furb
+    "FURB",
     # https://docs.astral.sh/ruff/rules/#isort-i
     "I",
     # https://docs.astral.sh/ruff/rules/#pep8-naming-n

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ docstring-code-format = true
 
 [tool.ruff.lint]
 select = [
+    # https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
+    "B",
     # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
     "E",
     # https://docs.astral.sh/ruff/rules/#pyflakes-f
@@ -57,6 +59,8 @@ select = [
 ]
 
 ignore = [
+    # `functools.cache` can leak memory: FIXME, I guess.
+    "B019",
     # A lot of “magic” values are easier to understand without a CONSTANT.
     "PLR2004",
     # I like to shadow `for` loop variables.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,14 @@ line-length = 80
 docstring-code-format = true
 
 [tool.ruff.lint]
-# I: isort
-extend-select = ["I"]
+# E: https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+# F: https://docs.astral.sh/ruff/rules/#pyflakes-f
+# I: https://docs.astral.sh/ruff/rules/#isort-i
+# N: https://docs.astral.sh/ruff/rules/#pep8-naming-n
+# PERF: https://docs.astral.sh/ruff/rules/#perflint-perf
+# RUF: https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
+select = ["E", "F", "I", "N", "PERF", "RUF"]
+ignore = ["E501", "N818", "PERF401", "RUF001", "RUF003", "RUF005", "RUF009", "RUF015", "RUF022"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["yanki"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ select = [
     "B",
     # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
     "E",
+    # https://docs.astral.sh/ruff/rules/#eradicate-era,
+    "ERA",
     # https://docs.astral.sh/ruff/rules/#pyflakes-f
     "F",
     # https://docs.astral.sh/ruff/rules/#isort-i

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -2,14 +2,15 @@ import inspect
 import io
 import json
 import os
-from pathlib import Path
-import psutil
-import pytest
 import signal
 import threading
 import time
 import urllib.error
+from pathlib import Path
 from urllib.request import urlopen
+
+import psutil
+import pytest
 
 
 def local_tests():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,12 @@
 import io
-import os
 import logging
-from pathlib import Path
-import pytest
-from pytest_console_scripts import ScriptRunner, _StrOrPath, RunResult
-from typing import Any
+import os
 import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pytest_console_scripts import RunResult, ScriptRunner, _StrOrPath
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ class YankiRunner(ScriptRunner):
     def __repr__(self) -> str:
         return f"<YankiRunner {self.launch_mode}>"
 
-    def run(
+    def run(  # noqa: PLR0913 (too many arguments)
         self,
         *arguments: _StrOrPath,
         print_result: bool | None = None,

--- a/tests/filter_test.py
+++ b/tests/filter_test.py
@@ -21,7 +21,7 @@ tags: -def
 """
 
 
-def filter_deck_tags(include=set(), exclude=set()):
+def filter_deck_tags(include=frozenset(), exclude=frozenset()):
     input = io.StringIO(REFERENCE_DECK)
     input.name = "-"
 

--- a/tests/note_test.py
+++ b/tests/note_test.py
@@ -1,7 +1,8 @@
 import asyncio
-from yanki.parser.config import NoteConfig, NOTE_VARIABLES
+
+from yanki.anki import FINAL_NOTE_VARIABLES, Note
 from yanki.parser import NoteSpec
-from yanki.anki import Note, FINAL_NOTE_VARIABLES
+from yanki.parser.config import NOTE_VARIABLES, NoteConfig
 from yanki.video import VideoOptions
 
 

--- a/tests/raw_to_html_test.py
+++ b/tests/raw_to_html_test.py
@@ -3,8 +3,8 @@ from yanki.field import raw_to_html
 
 def test_easy_url():
     assert (
-        raw_to_html("foo http://ex/?q=a&t=1#f bar\n")
-        == 'foo <a href="http://ex/?q=a&amp;t=1#f">http://ex/?q=a&amp;t=1#f</a> bar'
+        raw_to_html("a http://ex/?q=a&t=1#f b\n")
+        == 'a <a href="http://ex/?q=a&amp;t=1#f">http://ex/?q=a&amp;t=1#f</a> b'
     )
 
 
@@ -25,5 +25,6 @@ def test_md_link():
 def test_rst_link():
     assert (
         raw_to_html("rst:`link <http://ex/?q=a&t=1#f>`_\n")
-        == '<p><a class="reference external" href="http://ex/?q=a&amp;t=1#f">link</a></p>\n'
+        == '<p><a class="reference external" href="http://ex/?q=a&amp;t=1#f">'
+        "link</a></p>\n"
     )

--- a/tests/syntax_test.py
+++ b/tests/syntax_test.py
@@ -1,7 +1,8 @@
 import io
 import logging
-import pytest
 import textwrap
+
+import pytest
 
 from yanki.errors import DeckSyntaxError
 from yanki.parser import DeckFilesParser

--- a/tests/test-decks_test.py
+++ b/tests/test-decks_test.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from yanki.cli.decks import DeckSource

--- a/tests/test-decks_test.py
+++ b/tests/test-decks_test.py
@@ -1,8 +1,8 @@
 import os
 import pytest
 
-from yanki.cli import find_errors
 from yanki.cli.decks import DeckSource
+from yanki.utils import find_errors
 from yanki.video import VideoOptions
 
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from yanki.utils import NotFileURL, atomic_open, file_url_to_path
+from yanki.utils import NotFileURLError, atomic_open, file_url_to_path
 
 
 def test_atomic_open(tmp_path):
@@ -53,9 +53,9 @@ def test_atomic_open_deleted(tmp_path):
 
 
 def test_file_url_to_path():
-    with pytest.raises(NotFileURL):
+    with pytest.raises(NotFileURLError):
         file_url_to_path("foo")
-    with pytest.raises(NotFileURL):
+    with pytest.raises(NotFileURLError):
         file_url_to_path("http://example.com/foo")
 
     assert file_url_to_path("file://a/b/c") == Path("a/b/c")

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,9 +1,9 @@
 import os
 from pathlib import Path
+
 import pytest
 
-
-from yanki.utils import atomic_open, file_url_to_path, NotFileURL
+from yanki.utils import NotFileURL, atomic_open, file_url_to_path
 
 
 def test_atomic_open(tmp_path):

--- a/tests/video_parameters_test.py
+++ b/tests/video_parameters_test.py
@@ -13,7 +13,7 @@ def get_video(tmp_path):
     )
 
 
-def test_time_parse(tmp_path):
+def test_time_parse(tmp_path):  # noqa: PLR0915 (too many statements)
     video = get_video(tmp_path)
 
     assert video.get_fps() == 60

--- a/tests/video_parameters_test.py
+++ b/tests/video_parameters_test.py
@@ -1,4 +1,5 @@
 import pytest
+
 from yanki.video import Video, VideoOptions
 
 

--- a/yanki/anki.py
+++ b/yanki/anki.py
@@ -1,14 +1,15 @@
 import asyncio
-from dataclasses import dataclass
 import functools
-import genanki
 import hashlib
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
-from yanki.field import Fragment, ImageFragment, VideoFragment, Field
-from yanki.parser import DeckSpec, NoteSpec, NOTE_VARIABLES
+import genanki
+
+from yanki.field import Field, Fragment, ImageFragment, VideoFragment
+from yanki.parser import NOTE_VARIABLES, DeckSpec, NoteSpec
 from yanki.video import Video, VideoOptions
 
 LOGGER = logging.getLogger(__name__)

--- a/yanki/cli/__init__.py
+++ b/yanki/cli/__init__.py
@@ -49,8 +49,7 @@ WritableFilePath = functools.partial(
 )
 
 # Only used to pass debug logging status out to the exception handler.
-global log_debug
-log_debug = False
+global_log_debug = False
 
 
 def main():
@@ -67,11 +66,10 @@ def main():
             error.show()
             exit_code = error.exit_code
     except* FFmpegError as group:
-        global log_debug
         exit_code = 1
 
         for error in find_errors(group):
-            if log_debug:
+            if global_log_debug:
                 if error.stdout is not None:
                     sys.stderr.write("STDOUT:\n")
                     sys.stderr.buffer.write(error.stdout)
@@ -134,16 +132,16 @@ def cli(ctx, verbose, cache, reprocess, concurrency):
     )
 
     # Configure logging
-    global log_debug
+    global global_log_debug  # noqa: PLW0603 (global keyword)
     if verbose > 3:
         raise click.UsageError(
             "--verbose or -v may only be specified up to 3 times."
         )
     elif verbose == 3:
-        log_debug = True
+        global_log_debug = True
         level = logging.TRACE
     elif verbose == 2:
-        log_debug = True
+        global_log_debug = True
         level = logging.DEBUG
     elif verbose == 1:
         level = logging.INFO

--- a/yanki/cli/__init__.py
+++ b/yanki/cli/__init__.py
@@ -317,6 +317,7 @@ def to_json(options, output, decks, copy_media_to, html_media_prefix):
                     destination = copy_media_to / file_name
                     LOGGER.info(f"Copying media to {destination}")
                     shutil.copy2(source, destination)
+                    destination.chmod(0o644)
                     new_paths.append(str(destination))
 
                 note["media_paths"] = new_paths

--- a/yanki/cli/__init__.py
+++ b/yanki/cli/__init__.py
@@ -20,7 +20,7 @@ from yanki.anki import FINAL_NOTE_VARIABLES
 from yanki.errors import ExpectedError
 from yanki.html_out import write_html
 from yanki.parser import find_invalid_format, NOTE_VARIABLES
-from yanki.utils import add_trace_logging, open_in_app
+from yanki.utils import add_trace_logging, find_errors, open_in_app
 from yanki.video import BadURL, FFmpegError, Video, VideoOptions
 
 
@@ -431,15 +431,6 @@ def ensure_cache(cache_path: Path):
 
     tag_path = cache_path / "CACHEDIR.TAG"
     tag_path.write_text(CACHEDIR_TAG_CONTENT, encoding="ascii")
-
-
-def find_errors(group: ExceptionGroup):
-    """Get actual exceptions out of nested exception groups."""
-    for error in group.exceptions:
-        if isinstance(error, ExceptionGroup):
-            yield from find_errors(error)
-        else:
-            yield error
 
 
 if __name__ == "__main__":

--- a/yanki/cli/__init__.py
+++ b/yanki/cli/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import json
 import logging
 import os
@@ -29,6 +30,23 @@ from .server import server_options
 add_trace_logging()
 LOGGER = logging.getLogger(__name__)
 
+# Click path value types
+WritableDirectoryPath = functools.partial(
+    click.Path,
+    exists=False,
+    dir_okay=True,
+    file_okay=False,
+    writable=True,
+    readable=True,
+    executable=True,
+)
+WritableFilePath = functools.partial(
+    click.Path,
+    exists=False,
+    dir_okay=False,
+    file_okay=True,
+    writable=True,
+)
 
 # Only used to pass debug logging status out to the exception handler.
 global log_debug
@@ -82,14 +100,7 @@ def main():
     show_default=True,
     envvar="YANKI_CACHE",
     show_envvar=True,
-    type=click.Path(
-        exists=False,
-        file_okay=False,
-        writable=True,
-        readable=True,
-        executable=True,
-        path_type=Path,
-    ),
+    type=WritableDirectoryPath(path_type=Path),
     help="Path to cache for downloads and media files.",
 )
 @click.option(
@@ -163,7 +174,7 @@ def cli(ctx, verbose, cache, reprocess, concurrency):
 @click.option(
     "-o",
     "--output",
-    type=click.Path(exists=False, dir_okay=False, writable=True),
+    type=WritableFilePath(),
     help="Path to save decks to. Defaults to saving indivdual decks to their "
     "own files named after their sources, but with the extension .apkg.",
 )
@@ -243,16 +254,7 @@ def list_notes(options, decks, format):
 
 
 @cli.command()
-@click.argument(
-    "output",
-    type=click.Path(
-        exists=False,
-        dir_okay=True,
-        file_okay=False,
-        writable=True,
-        path_type=Path,
-    ),
-)
+@click.argument("output", type=WritableDirectoryPath(path_type=Path))
 @deck_parameters
 @click.option(
     "-F",
@@ -275,26 +277,14 @@ def to_html(options, output, decks, flashcards):
 @click.option(
     "-o",
     "--output",
-    type=click.Path(
-        exists=False,
-        dir_okay=False,
-        file_okay=True,
-        writable=True,
-        allow_dash=True,
-        path_type=Path,
-    ),
+    type=WritableFilePath(allow_dash=True, path_type=Path),
     default="-",
     help="Path to save JSON to, or - to output to stdout.",
 )
 @click.option(
     "-m",
     "--copy-media-to",
-    type=click.Path(
-        exists=False,
-        dir_okay=True,
-        file_okay=False,
-        writable=True,
-    ),
+    type=WritableDirectoryPath(),
     default="",
     help="Directory to copy media into (leave blank to not copy media).",
 )

--- a/yanki/cli/__init__.py
+++ b/yanki/cli/__init__.py
@@ -130,7 +130,7 @@ def cli(ctx, verbose, cache, reprocess, concurrency):
         cache_path=cache,
         progress=verbose > 0,
         reprocess=reprocess,
-        semaphore=asyncio.Semaphore(concurrency),
+        concurrency=concurrency,
     )
 
     # Configure logging

--- a/yanki/cli/__init__.py
+++ b/yanki/cli/__init__.py
@@ -1,32 +1,30 @@
-import click
 import asyncio
-import colorlog
-import genanki
 import json
 import logging
-from multiprocessing import cpu_count
 import os
 import os.path
-from pathlib import Path
 import re
 import shutil
 import sys
 import tempfile
 import traceback
-import yt_dlp
+from multiprocessing import cpu_count
+from pathlib import Path
 
+import click
+import colorlog
+import genanki
+import yt_dlp
 
 from yanki.anki import FINAL_NOTE_VARIABLES
 from yanki.errors import ExpectedError
 from yanki.html_out import write_html
-from yanki.parser import find_invalid_format, NOTE_VARIABLES
+from yanki.parser import NOTE_VARIABLES, find_invalid_format
 from yanki.utils import add_trace_logging, find_errors, open_in_app
 from yanki.video import BadURL, FFmpegError, Video, VideoOptions
 
-
 from .decks import deck_parameters
 from .server import server_options
-
 
 add_trace_logging()
 LOGGER = logging.getLogger(__name__)

--- a/yanki/cli/__init__.py
+++ b/yanki/cli/__init__.py
@@ -22,7 +22,7 @@ from yanki.errors import ExpectedError
 from yanki.html_out import write_html
 from yanki.parser import NOTE_VARIABLES, find_invalid_format
 from yanki.utils import add_trace_logging, find_errors, open_in_app
-from yanki.video import BadURL, FFmpegError, Video, VideoOptions
+from yanki.video import BadURLError, FFmpegError, Video, VideoOptions
 
 from .decks import deck_parameters
 from .server import server_options
@@ -377,7 +377,7 @@ def open_videos_from_file(options, files):
             try:
                 video = Video(url, options=options)
                 open_in_app([asyncio.run(video.processed_video_async())])
-            except BadURL as error:
+            except BadURLError as error:
                 print(f"Error: {error}")
             except yt_dlp.utils.DownloadError:
                 # yt_dlp prints the error itself.

--- a/yanki/cli/decks.py
+++ b/yanki/cli/decks.py
@@ -1,7 +1,7 @@
 import asyncio
 import functools
+from collections.abc import Generator
 from dataclasses import dataclass
-from typing import Generator, Set
 
 import click
 
@@ -15,8 +15,8 @@ class DeckSource:
     """Filter notes in decks."""
 
     files: list[click.File]
-    tags_include: Set[str] = frozenset()
-    tags_exclude: Set[str] = frozenset()
+    tags_include: set[str] = frozenset()
+    tags_exclude: set[str] = frozenset()
 
     def _include_note(self, note_spec: NoteSpec) -> bool:
         """Check if a note should be included based on tag filters."""

--- a/yanki/cli/decks.py
+++ b/yanki/cli/decks.py
@@ -29,10 +29,11 @@ class DeckSource:
 
     def filter_deck_spec(self, deck_spec: DeckSpec) -> Generator:
         """Filter notes in decks, only yielding decks that still have notes."""
-        filtered = []
-        for note_spec in deck_spec.note_specs:
-            if self._include_note(note_spec):
-                filtered.append(note_spec)
+        filtered = [
+            note_spec
+            for note_spec in deck_spec.note_specs
+            if self._include_note(note_spec)
+        ]
 
         if filtered:
             deck_spec.note_specs = filtered

--- a/yanki/cli/decks.py
+++ b/yanki/cli/decks.py
@@ -94,8 +94,8 @@ def deck_parameters(func):
         multiple=True,
         default=[],
         metavar="TAG",
-        help="Only include notes that have tag TAG. If specified multiple times, "
-        "notes must have all TAGs.",
+        help="Only include notes that have tag TAG. If specified multiple "
+        "times, notes must have all TAGs.",
     )
     @click.option(
         "-x",

--- a/yanki/cli/decks.py
+++ b/yanki/cli/decks.py
@@ -1,8 +1,9 @@
-from dataclasses import dataclass
-from typing import Set, Generator
-import functools
-import click
 import asyncio
+import functools
+from dataclasses import dataclass
+from typing import Generator, Set
+
+import click
 
 from yanki.anki import Deck
 from yanki.parser import DeckFilesParser, DeckSpec, NoteSpec

--- a/yanki/cli/decks.py
+++ b/yanki/cli/decks.py
@@ -43,9 +43,7 @@ class DeckSource:
         parser = DeckFilesParser()
         for file in self.files:
             for deck_spec in parser.parse_file(file.name, file):
-                # FIXME yield from?
-                for deck_spec in self.filter_deck_spec(deck_spec):
-                    yield deck_spec
+                yield from self.filter_deck_spec(deck_spec)
 
     def read(self, options: VideoOptions):
         """Read `Deck`s from `self.files`."""

--- a/yanki/cli/decks.py
+++ b/yanki/cli/decks.py
@@ -27,7 +27,7 @@ class DeckSource:
             and self.tags_exclude.isdisjoint(tags)
         )
 
-    def filter_deck_spec(self, deck_spec: DeckSpec) -> Generator:
+    def filter_deck_spec(self, deck_spec: DeckSpec) -> Generator[DeckSpec]:
         """Filter notes in decks, only yielding decks that still have notes."""
         filtered = [
             note_spec

--- a/yanki/cli/server.py
+++ b/yanki/cli/server.py
@@ -3,7 +3,6 @@ import http.server
 import threading
 import time
 from dataclasses import dataclass
-from typing import Tuple
 
 import click
 
@@ -23,7 +22,7 @@ class Server:
         self.bind_tuple  # noqa: B018 (not actually useless)
 
     @functools.cached_property
-    def bind_tuple(self) -> Tuple[str, int]:
+    def bind_tuple(self) -> tuple[str, int]:
         """Split --bind value into (address, port) and validate.
 
         Raises:

--- a/yanki/cli/server.py
+++ b/yanki/cli/server.py
@@ -20,7 +20,7 @@ class Server:
     def __post_init__(self):
         """Validate the configuration."""
         # Trigger validation by accessing the cached property
-        self.bind_tuple
+        self.bind_tuple  # noqa: B018 (not actually useless)
 
     @functools.cached_property
     def bind_tuple(self) -> Tuple[str, int]:
@@ -37,8 +37,8 @@ class Server:
 
         try:
             port = int(port_str)
-        except ValueError:
-            raise click.UsageError("--bind expects an integer port.")
+        except ValueError as error:
+            raise click.UsageError("--bind expects an integer port.") from error
 
         if not (1 <= port <= 65535):
             raise click.UsageError("--bind port must be between 1 and 65535.")

--- a/yanki/cli/server.py
+++ b/yanki/cli/server.py
@@ -1,10 +1,11 @@
-import click
-from dataclasses import dataclass
 import functools
 import http.server
 import threading
 import time
+from dataclasses import dataclass
 from typing import Tuple
+
+import click
 
 from yanki.utils import open_in_app
 

--- a/yanki/field.py
+++ b/yanki/field.py
@@ -124,7 +124,9 @@ class VideoFragment(MediaFragment):
 
 
 class Field:
-    def __init__(self, fragments: list[Fragment] = []):
+    def __init__(self, fragments: list[Fragment] | None = None):
+        if fragments is None:
+            fragments = []
         self.fragments = fragments
 
     def add_fragment(self, fragment: Fragment):

--- a/yanki/field.py
+++ b/yanki/field.py
@@ -13,9 +13,11 @@ URL_REGEX = re.compile(
     # URL with no surrounding parentheses
     (?<!\() \b(https?://[.?!,;:a-z0-9$_+*\'()/&=@#-]*[a-z0-9$_+*\'()/&=@#-])
     # URL with surrounding parentheses
-    | (?<=\() (https?://[.?!,;:a-z0-9$_+*\'()/&=@#-]*[a-z0-9$_+*\'()/&=@#-]) (?=\))
+    | (?<=\() (https?://[.?!,;:a-z0-9$_+*\'()/&=@#-]*[a-z0-9$_+*\'()/&=@#-])
+        (?=\))
     # URL with an initial parenthesis
-    | (?<=\() (https?://[.?!,;:a-z0-9$_+*\'()/&=@#-]*[a-z0-9$_+*\'()/&=@#-]) (?!\))
+    | (?<=\() (https?://[.?!,;:a-z0-9$_+*\'()/&=@#-]*[a-z0-9$_+*\'()/&=@#-])
+        (?!\))
     """,
     flags=re.IGNORECASE | re.VERBOSE,
 )

--- a/yanki/field.py
+++ b/yanki/field.py
@@ -1,10 +1,11 @@
-import docutils.core
-import html
 import functools
-import mistletoe
+import html
 import os
 import re
 from urllib.parse import quote
+
+import docutils.core
+import mistletoe
 
 # Regular expression to find http:// URLs in text.
 URL_REGEX = re.compile(

--- a/yanki/html_out.py
+++ b/yanki/html_out.py
@@ -83,8 +83,10 @@ def write_html(output_path, cache_path, decks, flashcards=False):
 
 
 def write_tree_indices(
-    tree, output_path, output_media_path, title_path=[], flashcards=False
+    tree, output_path, output_media_path, title_path=None, flashcards=False
 ):
+    if title_path is None:
+        title_path = []
     if tree.deck_file_name is None and title_path == [] and tree.name is None:
         # Anonymous root.
         if len(tree.children) == 1:

--- a/yanki/html_out.py
+++ b/yanki/html_out.py
@@ -90,7 +90,7 @@ def write_tree_indices(
         if len(tree.children) == 1:
             # If there is exactly one child of the anonymous root, then skip it.
             return write_tree_indices(
-                list(tree.children.values())[0],
+                next(iter(tree.children.values())),
                 output_path,
                 output_media_path,
                 flashcards=flashcards,

--- a/yanki/html_out.py
+++ b/yanki/html_out.py
@@ -1,9 +1,10 @@
-from collections import OrderedDict
-from html import escape as h
 import os
-from pathlib import Path
 import shutil
 import sys
+from collections import OrderedDict
+from html import escape as h
+from pathlib import Path
+
 from yanki.utils import file_safe_name
 
 

--- a/yanki/html_out.py
+++ b/yanki/html_out.py
@@ -234,6 +234,7 @@ def htmlize_deck(deck, title_path, path_prefix="", flashcards=False):
         else:
             clip_html = ""
 
+        video_url_html = h(note.spec.video_url())
         output += f"""
         <div class="note">
           <div class="cards">
@@ -262,7 +263,7 @@ def htmlize_deck(deck, title_path, path_prefix="", flashcards=False):
             <tr class="media">
               <th>Media:</th>
               <td>
-                <a href="{h(note.spec.video_url())}">{h(note.spec.video_url())}</a>
+                <a href="{video_url_html}">{video_url_html}</a>
                 {clip_html}
               </td>
             </tr>

--- a/yanki/html_out.py
+++ b/yanki/html_out.py
@@ -107,7 +107,7 @@ def write_tree_indices(
                 output_path / tree.deck_file_name,
                 output_media_path,
                 tree.deck,
-                title_path + [(tree.name, tree.deck_file_name)],
+                [*title_path, (tree.name, tree.deck_file_name)],
                 flashcards=flashcards,
             )
             return (
@@ -129,7 +129,7 @@ def write_tree_indices(
 
     # This rebinds the variable to a new value instead of changing the old
     # title_path object like .append() or += would:
-    title_path = title_path + [(tree.name, tree.index_file_name)]
+    title_path = [*title_path, (tree.name, tree.index_file_name)]
 
     list_html = [
         write_tree_indices(
@@ -148,7 +148,7 @@ def write_tree_indices(
             output_path / tree.deck_file_name,
             output_media_path,
             tree.deck,
-            title_path + [("Deck", tree.deck_file_name)],
+            [*title_path, ("Deck", tree.deck_file_name)],
             flashcards=flashcards,
         )
         deck_link = f'<a href="{h(tree.deck_file_name)}">Deck</a>'

--- a/yanki/parser/__init__.py
+++ b/yanki/parser/__init__.py
@@ -7,10 +7,10 @@ from .model import DeckSpec, NoteSpec
 from .parser import DeckFilesParser
 
 __all__ = [
-    "NoteConfigFrozen",
-    "find_invalid_format",
     "NOTE_VARIABLES",
-    "DeckSpec",
-    "NoteSpec",
     "DeckFilesParser",
+    "DeckSpec",
+    "NoteConfigFrozen",
+    "NoteSpec",
+    "find_invalid_format",
 ]

--- a/yanki/parser/__init__.py
+++ b/yanki/parser/__init__.py
@@ -1,7 +1,7 @@
 from .config import (
+    NOTE_VARIABLES,
     NoteConfigFrozen,
     find_invalid_format,
-    NOTE_VARIABLES,
 )
 from .model import DeckSpec, NoteSpec
 from .parser import DeckFilesParser

--- a/yanki/parser/config.py
+++ b/yanki/parser/config.py
@@ -39,9 +39,9 @@ def find_invalid_format(format, variables):
     """
     try:
         format.format(**dict.fromkeys(variables, "value"))
-        return None
     except KeyError as error:
         return error
+    return None
 
 
 @functools.cache

--- a/yanki/parser/config.py
+++ b/yanki/parser/config.py
@@ -1,10 +1,9 @@
 import dataclasses
-from dataclasses import field
 import functools
+from dataclasses import field
 
-from yanki.field import Fragment, Field
+from yanki.field import Field, Fragment
 from yanki.utils import make_frozen
-
 
 # Valid variables in note_id format. Used to validate that our code uses the
 # same variables in both places they’re needed.

--- a/yanki/parser/config.py
+++ b/yanki/parser/config.py
@@ -142,7 +142,7 @@ class NoteConfig:
         self.slow = (start, end, amount)
 
     def set_trim(self, trim):
-        if trim == "" or trim == "none":
+        if trim in {"", "none"}:
             self.trim = None
         else:
             clip = [part.strip() for part in trim.split("-")]
@@ -151,13 +151,13 @@ class NoteConfig:
             self.trim = (clip[0], clip[1])
 
     def set_audio(self, audio):
-        if audio == "include" or audio == "strip":
+        if audio in {"include", "strip"}:
             self.audio = audio
         else:
             raise ValueError('audio must be either "include" or "strip"')
 
     def set_video(self, video):
-        if video == "include" or video == "strip":
+        if video in {"include", "strip"}:
             self.video = video
         else:
             raise ValueError('video must be either "include" or "strip"')

--- a/yanki/parser/config.py
+++ b/yanki/parser/config.py
@@ -101,14 +101,15 @@ class NoteConfig:
                     pass
                 new_tags = None
             else:
-                # A tag without a + or - prefix, which implies we’re replacing all tags.
-                # FIXME: quoting so a tag with a + or - prefix can be used easily.
+                # No + or - prefix, which implies we’re replacing all tags.
+                # FIXME: quoting so a + or - prefix can be used easily.
                 found_bare_tag = True
 
         if found_bare_tag:
             if new_tags is None:
                 raise ValueError(
-                    f"Invalid mix of changing tags with setting tags: {input.strip()}"
+                    "Invalid mix of changing tags with setting tags: "
+                    f"{input.strip()}"
                 )
             self.tags = set(new_tags)
 

--- a/yanki/parser/parser.py
+++ b/yanki/parser/parser.py
@@ -1,7 +1,7 @@
-from copy import deepcopy
 import io
 import logging
 import re
+from copy import deepcopy
 
 from yanki.errors import DeckSyntaxError
 from yanki.parser.config import NoteConfig

--- a/yanki/utils.py
+++ b/yanki/utils.py
@@ -161,6 +161,7 @@ def open_in_app(arguments):
     command_line = [command, *arguments]
     result = subprocess.run(
         command_line,
+        check=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         encoding="utf_8",

--- a/yanki/utils.py
+++ b/yanki/utils.py
@@ -60,6 +60,15 @@ def file_safe_name(name):
     return name.replace("/", "--").replace(" ", "_")
 
 
+def find_errors(group: ExceptionGroup):
+    """Get actual exceptions out of nested exception groups."""
+    for error in group.exceptions:
+        if isinstance(error, ExceptionGroup):
+            yield from find_errors(error)
+        else:
+            yield error
+
+
 @contextlib.contextmanager
 def atomic_open(path, encoding="utf_8"):
     """

--- a/yanki/utils.py
+++ b/yanki/utils.py
@@ -35,7 +35,7 @@ def add_trace_logging():
 
 
 @contextlib.contextmanager
-def atomic_open(path, encoding="utf_8"):
+def atomic_open(path, encoding="utf_8", permissions=0o644):
     """
     Open a file for writing and save it atomically.
 
@@ -62,6 +62,7 @@ def atomic_open(path, encoding="utf_8"):
         yield temp_file
         os.rename(temp_file.name, path)
         # Nothing for NamedTemporaryFile to delete.
+        os.chmod(path, permissions)
 
 
 def chars_in(chars, input):

--- a/yanki/utils.py
+++ b/yanki/utils.py
@@ -1,16 +1,16 @@
 import contextlib
 import dataclasses
-from functools import partial, partialmethod
 import inspect
 import logging
 import os
-from pathlib import Path
-import tempfile
-import types
-import typing
 import shlex
 import subprocess
 import sys
+import tempfile
+import types
+import typing
+from functools import partial, partialmethod
+from pathlib import Path
 from urllib.parse import urlparse
 
 from yanki.errors import ExpectedError

--- a/yanki/utils.py
+++ b/yanki/utils.py
@@ -23,6 +23,7 @@ class NotFileURL(ValueError):
 
 
 def add_trace_logging():
+    """Add `logging.TRACE` level. Idempotent."""
     try:
         logging.TRACE
     except AttributeError:
@@ -64,6 +65,7 @@ def atomic_open(path, encoding="utf_8"):
 
 
 def chars_in(chars, input):
+    """Returns chars from `chars` that are in `input`."""
     return [char for char in chars if char in input]
 
 
@@ -104,6 +106,11 @@ def find_errors(group: ExceptionGroup):
 
 
 def get_key_path(data, path: list[any]):
+    """
+    Dig into `data` following the `path` of keys.
+
+    For example, `get_key_path(data, ["a", "b", 0]) == data["a"]["b"][0]`.
+    """
     for key in path:
         data = data[key]
     return data

--- a/yanki/utils.py
+++ b/yanki/utils.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 from yanki.errors import ExpectedError
 
 
-class NotFileURL(ValueError):
+class NotFileURLError(ValueError):
     """Raised by file_url_to_path() when the parameter is not a file:// URL."""
 
     pass
@@ -74,11 +74,11 @@ def file_url_to_path(url: str) -> Path:
     """
     Convert a file:// URL to a Path.
 
-    Raises NotFileURL if the URL is not a file:// URL.
+    Raises NotFileURLError if the URL is not a file:// URL.
     """
     parts = urlparse(url)
     if parts.scheme.lower() != "file":
-        raise NotFileURL(url)
+        raise NotFileURLError(url)
 
     # urlparse doesn’t handle file: very well:
     #

--- a/yanki/utils.py
+++ b/yanki/utils.py
@@ -25,7 +25,7 @@ class NotFileURLError(ValueError):
 def add_trace_logging():
     """Add `logging.TRACE` level. Idempotent."""
     try:
-        logging.TRACE
+        logging.TRACE  # noqa: B018 (not actually useless)
     except AttributeError:
         # From user DerWeh at https://stackoverflow.com/a/55276759/1043949
         logging.TRACE = 5

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -441,7 +441,7 @@ class Video:
         self._clip = self.time_to_seconds(time_spec, on_none=None)
 
     def crop(self, crop):
-        if crop == "none" or crop == "":
+        if crop in {"none", ""}:
             crop = None
         self._crop = crop
 
@@ -737,7 +737,7 @@ class Video:
         return stdout, stderr
 
     # Expect { 'v': video?, 'a' : audio? } depending on if -vn and -an are set.
-    def _try_apply_slow(self, streams):
+    def _try_apply_slow(self, streams):  # noqa: PLR0912 (too many branches)
         if self._slow is None:
             return streams
 

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -50,7 +50,7 @@ class FFmpegError(RuntimeError):
         stderr=None,
         exit_code=None,
     ):
-        super(FFmpegError, self).__init__(f"Error running {command}")
+        super().__init__(f"Error running {command}")
         self.command = command
         if command_line:
             self.add_note(f"Command run: {shlex.join(command_line)}")

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -67,7 +67,11 @@ class VideoOptions:
     cache_path: Path
     progress: bool = False
     reprocess: bool = False
-    semaphore: asyncio.Semaphore = asyncio.Semaphore(cpu_count())
+    concurrency: int = cpu_count()
+
+    @functools.cached_property
+    def semaphore(self):
+        return asyncio.Semaphore(self.concurrency)
 
 
 # Example YouTube video URLs:
@@ -132,7 +136,6 @@ def url_to_id(url_str):
     )
 
 
-# FIXME cannot be reused
 class Video:
     def __init__(
         self,

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -220,7 +220,11 @@ class Video:
                     ydl.extract_info(self.url, download=False)
                 )
         except yt_dlp.utils.YoutubeDLError as error:
-            raise BadURLError(f"Error downloading {self.url!r}: {error}")
+            # This is an ExpectedError, so the __cause__ won’t normally be
+            # displayed, so it’s included in the message.
+            raise BadURLError(
+                f"Error downloading {self.url!r}: {error}"
+            ) from error
 
     @functools.cache
     def info(self):
@@ -247,7 +251,7 @@ class Video:
         except ffmpeg.Error as error:
             raise FFmpegError(
                 command="ffprobe", stdout=error.stdout, stderr=error.stderr
-            )
+            ) from error
 
         with atomic_open(self.raw_metadata_cache_path()) as file:
             json.dump(self._raw_metadata, file)

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -369,13 +369,12 @@ class Video:
         )
         # FIXME use metadata=mode=print?
 
-        cropdetect = []
-        for line in err.split(b"\n"):
-            if matches := CROPDETECT_RE.search(line):
-                # (time, "crop"), e.g. (2.369, "1920:1072:0:4")
-                cropdetect.append(
-                    (float(matches[1]), matches[2].decode("utf_8"))
-                )
+        # (time, "crop"), e.g. (2.369, "1920:1072:0:4")
+        cropdetect = [
+            (float(matches[1]), matches[2].decode("utf_8"))
+            for line in err.split(b"\n")
+            if (matches := CROPDETECT_RE.search(line))
+        ]
 
         self._cached_more_info = {
             "version": MORE_INFO_VERSION,

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -629,7 +629,7 @@ class Video:
 
     # FIXME seems like there should be a separate FinalVideo class with this.
     def parameters_list(self):
-        """Get parameters for producing the video as list[str] (finalized version)."""
+        """Get video parameters list[str] (finalized version)."""
         if self._cached_parameters is None:
             raise ValueError("parameters_list() called on un-finalized Video")
         return sorted(

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -515,10 +515,11 @@ class Video:
         try:
             # If it’s a file:// URL, then there’s no need to cache.
             source_path = self.working_dir / file_url_to_path(self.url)
-            self.logger.info(f"using local raw video {source_path}")
-            return source_path
         except NotFileURLError:
             pass
+        else:
+            self.logger.info(f"using local raw video {source_path}")
+            return source_path
 
         if "ext" not in self.info():
             raise BadURLError(f"Invalid media URL {self.url!r}")

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -1,27 +1,28 @@
 import asyncio
-from dataclasses import dataclass
-import ffmpeg
 import functools
 import hashlib
 import json
 import logging
 import math
-from multiprocessing import cpu_count
-from pathlib import Path
-from os.path import getmtime
 import re
 import shlex
-from urllib.parse import urlparse, parse_qs
+from dataclasses import dataclass
+from multiprocessing import cpu_count
+from os.path import getmtime
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import ffmpeg
 import yt_dlp
 
 from yanki.errors import ExpectedError
 from yanki.utils import (
-    file_url_to_path,
-    file_not_empty,
-    atomic_open,
-    get_key_path,
-    chars_in,
     NotFileURL,
+    atomic_open,
+    chars_in,
+    file_not_empty,
+    file_url_to_path,
+    get_key_path,
 )
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
- **Move `find_errors` into `yanki.utils`.**
  

- **Alphabetize `yanki.utils`.**
  

- **Document functions in `yanki.utils`.**
  

- **Sort imports.**
  

- **Clarify `click` path types.**
  

- **`pyproject.toml`: Make indent consistent.**
  

- **`.editorconfig`: indents in TOML should be 4 spaces.**
  

- **Use 0644 permissions for cache and media files instead of 0600.**
  

- **FIX: use `yield from` instead of `yield` in a loop.**
  

- **Pre-commit checks: upgrade `ruff` checks.**
  

- **Lints: make selected and ignored lints explicit.**
  

- **E501: Limit all lines to 80 characters.**
  

- **N818: Fix exception classes to end with “Error”.**
  

- **PERF401: Use list comprehensions instead of `append()`.**
  

- **RUF001 – RUF003: ignore potentially confusing characters**
  I frequently use characters like `’` and `❯`, which trigger these lints.
  

- **RUF005: Use `[*my_list, ...]` instead of `my_list + [...]`.**
  

- **RUF009: Don’t call `Semaphore()` in field default**
  The field defaults in a `@dataclass` should be immutable, since the same
  object will be shared by all instances of the class using the default.
  (The default is only evaluated once.)
  

- **RUF015: Use `next(iter(...))` instead of `list(...)[0]`.**
  

- **RUF022: Sort `__all__`.**
  

- **TRY300: move `return` into `else:` instead of `try:`.**
  

- **PL: Enable PL lints**
  This also reformats lint configuration in `pyproject.toml` for clarity.
  

- **B: add flake8-bugbear lints.**
  

- **ERA: add lint to detect commented out code.**
  

- **UP: add pyupgrade lints.**
  

- **Add more type information to `Generator` return.**
  

- **FURB: add refurb lints.**
  