### PR TITLE
Miscellaneous clean ups and enable more lints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ ignore = [
     # Rule groups to fix or document:
     "ANN",
     "CPY",
-    "FBT",
     "FLY",
     "G",
     "PT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ ignore = [
     "A",        # I don’t mind shadowing built-ins.
     "B019",     # FIXME: `functools.cache` can leak memory.
     "COM812",   # Conflicts with formatter.
+    "CPY",      # I don’t want copyright notices at the top of every file.
     "D1",       # FIXME: Undocumented public items.
     "DOC",      # FIXME: Undocumented returns, raises, etc.
     "EM",       # I don’t like the `msg = ...; raise Error(msg)` syntax.
@@ -65,7 +66,6 @@ ignore = [
 
     # Rule groups to fix or document:
     "ANN",
-    "CPY",
     "FLY",
     "G",
     "PT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ ignore = [
 
     # Rule groups to fix or document:
     "ANN",
-    "C90",
     "CPY",
     "FBT",
     "FLY",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,6 @@ ignore = [
 
     # I frequently use characters that trigger these lints like "’"  and "❯":
     "RUF001", "RUF002", "RUF003",
-
-    # Rule groups to fix or document:
-    "SIM",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ ignore = [
 
     # Rule groups to fix or document:
     "ANN",
-    "ARG",
     "BLE",
     "C90",
     "CPY",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ ignore = [
     "RUF001", "RUF002", "RUF003",
 
     # Rule groups to fix or document:
-    "FLY",
     "PT",
     "PTH",
     "SIM",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ ignore = [
     "PLR2004",  # “Magic” values often easier to understand without a CONSTANT.
     "PLR6301",  # Too many false positive (methods that don’t need `self`).
     "PLW2901",  # I like to shadow `for` loop variables.
+    "PT011",    # `pytest.raises(...)` is too broad: Too many false positives.
     "S404",     # I use `subprocess`.
     "S603",     # This seems to trigger on all calls to `subprocess.run`.
     "T20",      # We use `print()`.
@@ -67,7 +68,6 @@ ignore = [
     "RUF001", "RUF002", "RUF003",
 
     # Rule groups to fix or document:
-    "PT",
     "PTH",
     "SIM",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ ignore = [
     "RUF001", "RUF002", "RUF003",
 
     # Rule groups to fix or document:
-    "PTH",
     "SIM",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ ignore = [
     "DOC",      # FIXME: Undocumented returns, raises, etc.
     "EM",       # I don’t like the `msg = ...; raise Error(msg)` syntax.
     "FIX",      # I like FIXME comments for low-priority stuff.
+    "G004",     # I prefer f-strings for logging for clarity.
     "PLC1901",  # Explicit comparisons to `""` are often clearer.
     "PLR0904",  # FIXME? Too many public methods.
     "PLR0911",  # I don’t care about too many returns.
@@ -67,7 +68,6 @@ ignore = [
     # Rule groups to fix or document:
     "ANN",
     "FLY",
-    "G",
     "PT",
     "PTH",
     "SIM",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ ignore = [
 
     # Rule groups to fix or document:
     "ANN",
-    "BLE",
     "C90",
     "CPY",
     "FBT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ ignore = [
     "FBT",
     "FLY",
     "G",
-    "LOG",
     "PT",
     "PTH",
     "SIM",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ preview = true
 select = ["ALL"]
 ignore = [
     "A",        # I don’t mind shadowing built-ins.
+    "ANN",      # FIXME? type annotations.
     "B019",     # FIXME: `functools.cache` can leak memory.
     "COM812",   # Conflicts with formatter.
     "CPY",      # I don’t want copyright notices at the top of every file.
@@ -66,7 +67,6 @@ ignore = [
     "RUF001", "RUF002", "RUF003",
 
     # Rule groups to fix or document:
-    "ANN",
     "FLY",
     "PT",
     "PTH",

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -115,7 +115,7 @@ def test_yanki_to_html(yanki, deck_1_path, output_path):
     assert "<img " in index_html
 
 
-def test_yanki_to_json(yanki, deck_1_path, output_path):
+def test_yanki_to_json(yanki, deck_1_path):
     result = yanki.run("to-json", deck_1_path)
     assert result.returncode == 0
     assert result.stderr == ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,7 @@ class YankiRunner(ScriptRunner):
         rootdir: Path,
         bin_path: Path,
         cache_path: Path,
+        *,
         print_result: bool = True,
     ):
         super().__init__(launch_mode, rootdir, print_result)
@@ -130,7 +131,10 @@ def yanki(
     bin_path: Path,
     cache_path: Path,
 ) -> YankiRunner:
-    print_result = not request.config.getoption("--hide-run-results")
     return YankiRunner(
-        script_launch_mode, script_cwd, bin_path, cache_path, print_result
+        script_launch_mode,
+        script_cwd,
+        bin_path,
+        cache_path,
+        print_result=not request.config.getoption("--hide-run-results"),
     )

--- a/tests/filter_test.py
+++ b/tests/filter_test.py
@@ -39,22 +39,22 @@ def filter_deck_tags(include=frozenset(), exclude=frozenset()):
 
 
 def test_filters():
-    assert "ABCDEF" == filter_deck_tags()
-    assert "ABC" == filter_deck_tags(include=["abc"])
-    assert "DEF" == filter_deck_tags(exclude=["abc"])
-    assert "" == filter_deck_tags(include=["abc"], exclude=["abc"])
-    assert "ABC" == filter_deck_tags(include=["abc"], exclude=["def"])
-    assert "A" == filter_deck_tags(include=["abc"], exclude=["bcd"])
+    assert filter_deck_tags() == "ABCDEF"
+    assert filter_deck_tags(include=["abc"]) == "ABC"
+    assert filter_deck_tags(exclude=["abc"]) == "DEF"
+    assert filter_deck_tags(include=["abc"], exclude=["abc"]) == ""
+    assert filter_deck_tags(include=["abc"], exclude=["def"]) == "ABC"
+    assert filter_deck_tags(include=["abc"], exclude=["bcd"]) == "A"
 
 
 def test_multiple_include():
-    assert "BC" == filter_deck_tags(include=["abc", "bcd"])
-    assert "C" == filter_deck_tags(include=["abc", "bcd"], exclude=["b"])
+    assert filter_deck_tags(include=["abc", "bcd"]) == "BC"
+    assert filter_deck_tags(include=["abc", "bcd"], exclude=["b"]) == "C"
 
 
 def test_multiple_exclude():
-    assert "EF" == filter_deck_tags(exclude=["abc", "bcd"])
-    assert "E" == filter_deck_tags(include=["e"], exclude=["abc", "bcd"])
+    assert filter_deck_tags(exclude=["abc", "bcd"]) == "EF"
+    assert filter_deck_tags(include=["e"], exclude=["abc", "bcd"]) == "E"
 
 
 def test_read_decks_sorted(deck_1_path, deck_2_path, cache_path):

--- a/tests/filter_test.py
+++ b/tests/filter_test.py
@@ -60,8 +60,8 @@ def test_multiple_exclude():
 def test_read_decks_sorted(deck_1_path, deck_2_path, cache_path):
     decks = DeckSource(
         files=[
-            open(deck_2_path, "r", encoding="utf_8"),
-            open(deck_1_path, "r", encoding="utf_8"),
+            deck_2_path.open("r", encoding="utf_8"),
+            deck_1_path.open("r", encoding="utf_8"),
         ]
     ).read_sorted(VideoOptions(cache_path))
 
@@ -73,8 +73,8 @@ def test_read_decks_sorted(deck_1_path, deck_2_path, cache_path):
 def test_read_final_decks_sorted(deck_1_path, deck_2_path, cache_path):
     decks = DeckSource(
         files=[
-            open(deck_2_path, "r", encoding="utf_8"),
-            open(deck_1_path, "r", encoding="utf_8"),
+            deck_2_path.open("r", encoding="utf_8"),
+            deck_1_path.open("r", encoding="utf_8"),
         ]
     ).read_final_sorted(VideoOptions(cache_path))
 

--- a/tests/html_test.py
+++ b/tests/html_test.py
@@ -8,7 +8,7 @@ from yanki.video import VideoOptions
 
 def test_two_decks(cache_path, deck_1_path, deck_2_path, output_path):
     files = [
-        open(path, "r", encoding="utf_8") for path in [deck_1_path, deck_2_path]
+        path.open("r", encoding="utf_8") for path in [deck_1_path, deck_2_path]
     ]
 
     write_html(

--- a/tests/syntax_test.py
+++ b/tests/syntax_test.py
@@ -81,7 +81,7 @@ def test_group():
 
 
 @pytest.mark.parametrize(
-    "lines,more_html",
+    ("lines", "more_html"),
     [
         (["more: one"], "one"),
         (["more: one", "more: two"], "two"),
@@ -99,7 +99,7 @@ def test_deck_more_parametrized(lines, more_html):
 
 
 @pytest.mark.parametrize(
-    "lines,overlay_text",
+    ("lines", "overlay_text"),
     [
         (["overlay_text: one"], "one"),
         (["overlay_text: one", ""], "one"),
@@ -117,7 +117,7 @@ def test_deck_overlay_text_parametrized(lines, overlay_text):
 
 
 @pytest.mark.parametrize(
-    "lines,overlay_text",
+    ("lines", "overlay_text"),
     [
         (["  overlay_text:"], ""),
         (["  overlay_text:", ""], ""),
@@ -164,7 +164,7 @@ def test_note_overlay_text_parametrized(lines, overlay_text):
 
 
 @pytest.mark.parametrize(
-    "note_lines,parsed_text",
+    ("note_lines", "parsed_text"),
     [
         (["one", "  two", "  \t", "  three"], "one\ntwo\n\nthree"),
         (["one", "  two", "  ", "  three"], "one\ntwo\n\nthree"),
@@ -223,7 +223,7 @@ def test_note_parametrized(note_lines, parsed_text):
 
 
 @pytest.mark.parametrize(
-    "deck,message",
+    ("deck", "message"),
     [
         ("  bad", "Error in -, line 1: Unexpected indent"),
         (

--- a/tests/test-decks_test.py
+++ b/tests/test-decks_test.py
@@ -21,9 +21,11 @@ def read_first_line(path: Path):
 @pytest.mark.parametrize("path", find_deck_files("test-decks/errors"))
 def test_deck_error(path, cache_path):
     options = VideoOptions(cache_path=cache_path)
-    with path.open("r", encoding="utf_8") as file:
-        with pytest.raises(ExceptionGroup) as error_info:
-            DeckSource(files=[file]).read_final(options)
+    with (
+        path.open("r", encoding="utf_8") as file,
+        pytest.raises(ExceptionGroup) as error_info,
+    ):
+        DeckSource(files=[file]).read_final(options)
 
     [error] = list(find_errors(error_info.value))
 

--- a/tests/test-decks_test.py
+++ b/tests/test-decks_test.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 
@@ -8,14 +8,11 @@ from yanki.video import VideoOptions
 
 
 def find_deck_files(base_path):
-    for dir_path, _, file_names in os.walk(base_path):
-        for file_name in file_names:
-            if file_name.endswith(".deck"):
-                yield f"{dir_path}/{file_name}"
+    yield from Path(base_path).rglob("*.deck")
 
 
-def read_first_line(path):
-    with open(path, "r", encoding="utf_8") as input:
+def read_first_line(path: Path):
+    with path.open("r", encoding="utf_8") as input:
         for line in input:
             return line
     return None
@@ -24,7 +21,7 @@ def read_first_line(path):
 @pytest.mark.parametrize("path", find_deck_files("test-decks/errors"))
 def test_deck_error(path, cache_path):
     options = VideoOptions(cache_path=cache_path)
-    with open(path, "r", encoding="utf_8") as file:
+    with path.open("r", encoding="utf_8") as file:
         with pytest.raises(ExceptionGroup) as error_info:
             DeckSource(files=[file]).read_final(options)
 
@@ -39,6 +36,6 @@ def test_deck_error(path, cache_path):
 @pytest.mark.parametrize("path", find_deck_files("test-decks/good"))
 def test_deck_success(path, cache_path):
     options = VideoOptions(cache_path=cache_path)
-    with open(path, "r", encoding="utf_8") as file:
+    with path.open("r", encoding="utf_8") as file:
         [deck] = DeckSource(files=[file]).read_final(options)
     assert len(deck.notes()) >= 1

--- a/tests/test-decks_test.py
+++ b/tests/test-decks_test.py
@@ -25,7 +25,7 @@ def read_first_line(path):
 def test_deck_error(path, cache_path):
     options = VideoOptions(cache_path=cache_path)
     with open(path, "r", encoding="utf_8") as file:
-        with pytest.raises(Exception) as error_info:
+        with pytest.raises(ExceptionGroup) as error_info:
             DeckSource(files=[file]).read_final(options)
 
     [error] = list(find_errors(error_info.value))

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -46,7 +45,7 @@ def test_atomic_open_deleted(tmp_path):
     with pytest.raises(FileNotFoundError) as error_info:  # noqa: PT012
         # Ignore PT012: testing context manager
         with atomic_open(path) as file:
-            os.unlink(file.name)
+            Path(file.name).unlink()
             file.write("First write\n")
     assert error_info.match("No such file or directory")
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -27,8 +27,9 @@ def test_atomic_open_error(tmp_path):
     assert path.read_text() == "First write\n"
     assert [path.name for path in tmp_path.iterdir()] == ["prefix.suffix"]
 
-    with pytest.raises(RuntimeError) as error_info:  # noqa: PT012
-        # Ignore PT012: we check for the specific `raise`
+    with pytest.raises(RuntimeError) as error_info:  # noqa: PT012 SIM117
+        # Ignore PT012: we check for the specific `raise`.
+        # Ignore SIM117: nested `with`s makes this more clear.
         with atomic_open(path) as file:
             file.write("Second write\n")
             file.close()
@@ -42,8 +43,9 @@ def test_atomic_open_error(tmp_path):
 def test_atomic_open_deleted(tmp_path):
     path = tmp_path / "prefix.suffix"
 
-    with pytest.raises(FileNotFoundError) as error_info:  # noqa: PT012
-        # Ignore PT012: testing context manager
+    with pytest.raises(FileNotFoundError) as error_info:  # noqa: PT012 SIM117
+        # Ignore PT012: testing context manager.
+        # Ignore SIM117: nested `with`s makes this more clear.
         with atomic_open(path) as file:
             Path(file.name).unlink()
             file.write("First write\n")

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -28,7 +28,8 @@ def test_atomic_open_error(tmp_path):
     assert path.read_text() == "First write\n"
     assert [path.name for path in tmp_path.iterdir()] == ["prefix.suffix"]
 
-    with pytest.raises(RuntimeError) as error_info:
+    with pytest.raises(RuntimeError) as error_info:  # noqa: PT012
+        # Ignore PT012: we check for the specific `raise`
         with atomic_open(path) as file:
             file.write("Second write\n")
             file.close()
@@ -42,7 +43,8 @@ def test_atomic_open_error(tmp_path):
 def test_atomic_open_deleted(tmp_path):
     path = tmp_path / "prefix.suffix"
 
-    with pytest.raises(FileNotFoundError) as error_info:
+    with pytest.raises(FileNotFoundError) as error_info:  # noqa: PT012
+        # Ignore PT012: testing context manager
         with atomic_open(path) as file:
             os.unlink(file.name)
             file.write("First write\n")

--- a/yanki/anki.py
+++ b/yanki/anki.py
@@ -275,14 +275,14 @@ class FinalNote:
             tags=self.spec.config.tags,
         )
 
-    def to_dict(self, base_path=""):
+    def to_dict(self, base_url=""):
         """Recursively convert to dict."""
         return {
             "deck_id": self.deck_id,
             "note_id": self.note_id,
-            "text_html": self.text_field().render_html(base_path=base_path),
-            "media_html": self.media_field().render_html(base_path=base_path),
-            "more_html": self.more_field().render_html(base_path=base_path),
+            "text_html": self.text_field().render_html(base_url=base_url),
+            "media_html": self.media_field().render_html(base_url=base_url),
+            "more_html": self.more_field().render_html(base_url=base_url),
             "media_paths": sorted(self.media_paths()),
             "direction": self.spec.direction(),
             "tags": sorted(self.spec.config.tags),
@@ -344,15 +344,13 @@ class FinalDeck:
 
         return path
 
-    def to_dict(self, base_path=""):
+    def to_dict(self, base_url=""):
         """Recursively convert to dict."""
         return {
             "deck_id": self.deck_id,
             "title": self.title,
             "source_path": self.source_path,
-            "notes": [
-                note.to_dict(base_path=base_path) for note in self.notes()
-            ],
+            "notes": [note.to_dict(base_url=base_url) for note in self.notes()],
         }
 
 

--- a/yanki/anki.py
+++ b/yanki/anki.py
@@ -2,7 +2,6 @@ import asyncio
 import functools
 import hashlib
 import logging
-import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -117,11 +116,10 @@ class Note:
 
     @functools.cache
     def video(self):
-        deck_dir = os.path.dirname(self.spec.source_path)
         try:
             video = Video(
                 self.spec.video_url(),
-                working_dir=Path(deck_dir),
+                working_dir=Path(self.spec.source_path).parent,
                 options=self.video_options,
                 logger=self.logger,
             )
@@ -334,8 +332,10 @@ class FinalDeck:
         package.decks.append(deck)
 
     def save_to_file(self, path=None):
-        if not path:
-            path = os.path.splitext(self.source_path)[0] + ".apkg"
+        if path:
+            path = Path(path)
+        else:
+            path = Path(self.source_path).with_suffix(".apkg")
 
         package = genanki.Package([])
         self.save_to_package(package)

--- a/yanki/cli/__init__.py
+++ b/yanki/cli/__init__.py
@@ -52,7 +52,7 @@ WritableFilePath = functools.partial(
 global_log_debug = False
 
 
-def main():
+def main():  # noqa: C901 (complex)
     exit_code = 0
     try:
         cli.main(standalone_mode=False)

--- a/yanki/cli/__init__.py
+++ b/yanki/cli/__init__.py
@@ -297,7 +297,7 @@ def to_json(options, output, decks, copy_media_to, html_media_prefix):
     Optionally, copy the media for the decks into a directory.
     """
     decks = [
-        deck.to_dict(base_path=html_media_prefix)
+        deck.to_dict(base_url=html_media_prefix)
         for deck in decks.read_final_sorted(options)
     ]
 

--- a/yanki/cli/__init__.py
+++ b/yanki/cli/__init__.py
@@ -145,7 +145,7 @@ def cli(ctx, verbose, cache, reprocess, concurrency):
     elif verbose == 1:
         level = logging.INFO
     else:
-        level = logging.WARN
+        level = logging.WARNING
 
     handler = colorlog.StreamHandler()
     handler.setFormatter(

--- a/yanki/cli/__init__.py
+++ b/yanki/cli/__init__.py
@@ -2,8 +2,6 @@ import asyncio
 import functools
 import json
 import logging
-import os
-import os.path
 import re
 import shutil
 import sys
@@ -308,8 +306,7 @@ def to_json(options, output, decks, copy_media_to, html_media_prefix):
             for note in deck["notes"]:
                 new_paths = []
                 for source in note["media_paths"]:
-                    file_name = os.path.basename(source)
-                    destination = copy_media_to / file_name
+                    destination = copy_media_to / Path(source).name
                     LOGGER.info(f"Copying media to {destination}")
                     shutil.copy2(source, destination)
                     destination.chmod(0o644)

--- a/yanki/field.py
+++ b/yanki/field.py
@@ -1,7 +1,7 @@
 import functools
 import html
-import os
 import re
+from pathlib import Path
 from urllib.parse import quote
 
 import docutils.core
@@ -68,12 +68,12 @@ class Fragment:
 
 
 class MediaFragment(Fragment):
-    def __init__(self, path, media):
+    def __init__(self, path: Path, media):
         self.path = path
         self._media = media
 
     def file_name(self):
-        return os.path.basename(self.path)
+        return self.path.name
 
     def path_in_base(self, _base_url):
         return

--- a/yanki/field.py
+++ b/yanki/field.py
@@ -57,7 +57,7 @@ class Fragment:
     def render_anki(self):
         return self.render_html("")
 
-    def render_html(self, base_path=""):
+    def render_html(self, _base_path=""):
         return raw_to_html(self.raw)
 
     def __str__(self):
@@ -75,7 +75,7 @@ class MediaFragment(Fragment):
     def file_name(self):
         return os.path.basename(self.path)
 
-    def path_in_base(self, base_path):
+    def path_in_base(self, _base_path):
         return
 
     def anki_filename(self):

--- a/yanki/field.py
+++ b/yanki/field.py
@@ -57,7 +57,7 @@ class Fragment:
     def render_anki(self):
         return self.render_html("")
 
-    def render_html(self, _base_path=""):
+    def render_html(self, _base_url=""):
         return raw_to_html(self.raw)
 
     def __str__(self):
@@ -75,7 +75,7 @@ class MediaFragment(Fragment):
     def file_name(self):
         return os.path.basename(self.path)
 
-    def path_in_base(self, _base_path):
+    def path_in_base(self, _base_url):
         return
 
     def anki_filename(self):
@@ -85,15 +85,15 @@ class MediaFragment(Fragment):
         # &#x27;, which then gets transformed to &amp;%23x27; at some point.
         return self.file_name()
 
-    def html_path_in_base(self, base_path):
-        """Get the path relative to base_path, and encoded for HTML.
+    def html_path_in_base(self, base_url: str):
+        """Get the path relative to base_url, and encoded for HTML.
 
-        base_path may be a URL or a relative path. It must already be URL
-        encoded, but must not escaped for HTML.
+        base_url may be a absolute or relative URL.
         """
-        return html.escape(
-            os.path.join(base_path, quote(self.file_name(), encoding="utf_8"))
-        )
+        quoted_file_name = quote(self.file_name(), encoding="utf_8")
+        if base_url == "":
+            return html.escape(quoted_file_name)
+        return html.escape(f"{base_url}/{quoted_file_name}")
 
     def media(self):
         return [self._media]
@@ -106,18 +106,18 @@ class ImageFragment(MediaFragment):
     def render_anki(self):
         return f'<img src="{self.anki_filename()}" />'
 
-    def render_html(self, base_path=""):
-        return f'<img src="{self.html_path_in_base(base_path)}" />'
+    def render_html(self, base_url=""):
+        return f'<img src="{self.html_path_in_base(base_url)}" />'
 
 
 class VideoFragment(MediaFragment):
     def render_anki(self):
         return f"[sound:{self.anki_filename()}]"
 
-    def render_html(self, base_path="."):
+    def render_html(self, base_url="."):
         return (
             "<video controls playsinline "
-            f'src="{self.html_path_in_base(base_path)}"></video>'
+            f'src="{self.html_path_in_base(base_url)}"></video>'
         )
 
 
@@ -141,9 +141,9 @@ class Field:
     def render_anki(self):
         return "".join([fragment.render_anki() for fragment in self.fragments])
 
-    def render_html(self, base_path=""):
+    def render_html(self, base_url=""):
         return "".join(
-            [fragment.render_html(base_path) for fragment in self.fragments]
+            [fragment.render_html(base_url) for fragment in self.fragments]
         )
 
     def __str__(self):

--- a/yanki/html_out.py
+++ b/yanki/html_out.py
@@ -27,7 +27,7 @@ class DeckTree:
         return self
 
 
-def write_html(output_path, cache_path, decks, flashcards=False):
+def write_html(output_path, cache_path, decks, *, flashcards=False):
     """Write HTML version of decks to a path."""
     if output_path == cache_path:
         # Serving HTML from the cache; no need to copy media.
@@ -82,7 +82,7 @@ def write_html(output_path, cache_path, decks, flashcards=False):
 
 
 def write_tree_indices(
-    tree, output_path, output_media_path, title_path=None, flashcards=False
+    tree, output_path, output_media_path, *, title_path=None, flashcards=False
 ):
     if title_path is None:
         title_path = []
@@ -136,7 +136,7 @@ def write_tree_indices(
             child,
             output_path,
             output_media_path,
-            title_path,
+            title_path=title_path,
             flashcards=flashcards,
         )
         for child in tree.children.values()
@@ -185,7 +185,7 @@ def generate_index_html(deck_link_html, child_html, title_path):
 
 
 def write_deck_files(
-    html_path, output_media_path, deck, title_path, flashcards=False
+    html_path, output_media_path, deck, title_path, *, flashcards=False
 ):
     html_path.write_text(
         htmlize_deck(deck, title_path, path_prefix="", flashcards=flashcards),
@@ -201,7 +201,7 @@ def write_deck_files(
             output_path.chmod(0o644)
 
 
-def htmlize_deck(deck, title_path, path_prefix="", flashcards=False):
+def htmlize_deck(deck, title_path, *, path_prefix="", flashcards=False):
     if deck.title is None:
         sys.exit(f"Deck {deck.source_path!r} does not contain title")
 
@@ -276,7 +276,7 @@ def htmlize_deck(deck, title_path, path_prefix="", flashcards=False):
     """.replace("\n    ", "\n").lstrip()
 
 
-def title_html(title_path, add_links=True, final_link=True):
+def title_html(title_path, *, add_links=True, final_link=True):
     if not title_path:
         return ""
     if not add_links:

--- a/yanki/html_out.py
+++ b/yanki/html_out.py
@@ -308,12 +308,12 @@ def ensure_static_link(cache_path: Path):
 
     try:
         static_path.unlink()
-    except Exception as e:
+    except OSError as e:
         sys.exit(f"Error removing {static_path} to replace with symlink: {e}")
 
     try:
         static_path.symlink_to(web_files_path)
-    except Exception as e:
+    except OSError as e:
         sys.exit(f"Error symlinking {static_path} to {web_files_path}: {e}")
 
 

--- a/yanki/html_out.py
+++ b/yanki/html_out.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import sys
 from collections import OrderedDict
@@ -195,7 +194,7 @@ def write_deck_files(
     # Copy media to output.
     if output_media_path is not None:
         for path in deck.media_paths():
-            output_path = output_media_path / os.path.basename(path)
+            output_path = output_media_path / Path(path).name
             shutil.copy2(path, output_path)
             # Make sure media is accessible by the web server.
             output_path.chmod(0o644)
@@ -322,5 +321,5 @@ def path_to_web_files() -> Path:
 
 
 def static_url(path) -> str:
-    mtime = os.path.getmtime(path_to_web_files() / path)
+    mtime = (path_to_web_files() / path).stat().st_mtime
     return f"static/{path}?{mtime}"

--- a/yanki/parser/config.py
+++ b/yanki/parser/config.py
@@ -1,3 +1,4 @@
+import contextlib
 import dataclasses
 import functools
 from dataclasses import field
@@ -96,10 +97,8 @@ class NoteConfig:
                 self.tags.add(tag[1:])
                 new_tags = None
             elif tag.startswith("-"):
-                try:
+                with contextlib.suppress(KeyError):
                     self.tags.remove(tag[1:])
-                except KeyError:
-                    pass
                 new_tags = None
             else:
                 # No + or - prefix, which implies we’re replacing all tags.
@@ -175,7 +174,7 @@ class NoteConfig:
 
     def generate_note_id(self, **kwargs):
         passed_keys = set(kwargs.keys())
-        if NOTE_VARIABLES != passed_keys:
+        if passed_keys != NOTE_VARIABLES:
             raise KeyError(
                 "Incorrect variables passed to generate_note_id()\n"
                 f"  unknown: {sorted(passed_keys - NOTE_VARIABLES)}\n"

--- a/yanki/parser/model.py
+++ b/yanki/parser/model.py
@@ -25,7 +25,7 @@ class NoteSpec:
             "url": self.video_url(),
             "clip": self.provisional_clip_spec(),
             "direction": self.direction(),
-            "media": " ".join([self.video_url(), self.provisional_clip_spec()]),
+            "media": f"{self.video_url()} {self.provisional_clip_spec()}",
             "text": self.text(),
             "line_number": self.line_number,
             "source_path": self.source_path,

--- a/yanki/parser/parser.py
+++ b/yanki/parser/parser.py
@@ -233,7 +233,7 @@ class ConfigParser(SubParser):
         # Don’t even look for config directives.
         self.text.append(line)
 
-    def parse_config(self, directive, rest):
+    def parse_config(self, _directive, _rest):
         raise RuntimeError(
             "parse_config() should be unreachable in ConfigParser"
         )

--- a/yanki/parser/parser.py
+++ b/yanki/parser/parser.py
@@ -2,6 +2,7 @@ import io
 import logging
 import re
 from copy import deepcopy
+from pathlib import Path
 
 from yanki.errors import DeckSyntaxError
 from yanki.parser.config import NoteConfig
@@ -300,7 +301,7 @@ class DeckFilesParser:
         yield from self.flush_decks()
 
     def parse_path(self, path):
-        with open(path, "r", encoding="utf_8") as file:
+        with Path(path).open("r", encoding="utf_8") as file:
             yield from self.parse_file(file.name, file)
 
     def parse_input(self, input):

--- a/yanki/utils.py
+++ b/yanki/utils.py
@@ -39,13 +39,8 @@ def atomic_open(path: Path, *, encoding="utf_8", permissions=0o644):
     This creates a temporary file in the same directory, writes to it, then
     replaces the target file atomically even if it already exists.
     """
-    if encoding is None:
-        mode = "wb"
-    else:
-        mode = "w"
-
     with tempfile.NamedTemporaryFile(
-        mode=mode,
+        mode="wb" if encoding is None else "w",
         encoding=encoding,
         dir=path.parent,
         prefix=f"working_{path.stem}",

--- a/yanki/utils.py
+++ b/yanki/utils.py
@@ -44,21 +44,20 @@ def atomic_open(path, encoding="utf_8", permissions=0o644):
     else:
         mode = "w"
 
-    directory = os.path.dirname(path)
-    (prefix, suffix) = os.path.splitext(os.path.basename(path))
+    path = Path(path)
     with tempfile.NamedTemporaryFile(
         mode=mode,
         encoding=encoding,
-        dir=directory,
-        prefix=f"working_{prefix}",
-        suffix=suffix,
+        dir=path.parent,
+        prefix=f"working_{path.stem}",
+        suffix=path.suffix,
         delete=True,
         delete_on_close=False,
     ) as temp_file:
         yield temp_file
-        os.rename(temp_file.name, path)
+        Path(temp_file.name).rename(path)
         # Nothing for NamedTemporaryFile to delete.
-        os.chmod(path, permissions)
+        path.chmod(permissions)
 
 
 def chars_in(chars, input):
@@ -82,9 +81,9 @@ def file_url_to_path(url: str) -> Path:
     return Path(parts.netloc + parts.path)
 
 
-def file_not_empty(path):
+def file_not_empty(path: Path):
     """Check that `path` is a file and is non-empty."""
-    return os.path.exists(path) and os.stat(path).st_size > 0
+    return path.exists() and path.stat().st_size > 0
 
 
 def file_safe_name(name):

--- a/yanki/utils.py
+++ b/yanki/utils.py
@@ -33,7 +33,7 @@ def add_trace_logging():
 
 
 @contextlib.contextmanager
-def atomic_open(path, encoding="utf_8", permissions=0o644):
+def atomic_open(path: Path, *, encoding="utf_8", permissions=0o644):
     """Open a file for writing and save it atomically.
 
     This creates a temporary file in the same directory, writes to it, then
@@ -44,7 +44,6 @@ def atomic_open(path, encoding="utf_8", permissions=0o644):
     else:
         mode = "w"
 
-    path = Path(path)
     with tempfile.NamedTemporaryFile(
         mode=mode,
         encoding=encoding,

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -734,7 +734,7 @@ class Video:
         return stdout, stderr
 
     # Expect { 'v': video?, 'a' : audio? } depending on if -vn and -an are set.
-    def _try_apply_slow(self, streams):  # noqa: PLR0912 (too many branches)
+    def _try_apply_slow(self, streams):  # noqa: C901 PLR0912 (FIXME complex)
         if self._slow is None:
             return streams
 

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -303,7 +303,7 @@ class Video:
         if spec == "" or spec is None:
             return on_none
 
-        if isinstance(spec, float) or isinstance(spec, int):
+        if isinstance(spec, (float, int)):
             return float(spec)
 
         if spec[-1] in "Ff":
@@ -431,12 +431,11 @@ class Video:
     def clip(self, start_spec, end_spec):
         start = self.time_to_seconds(start_spec, on_none=0)
         end = self.time_to_seconds(end_spec, on_none=None)
-        if end is not None:
-            if end - start <= 0:
-                raise ValueError(
-                    "Cannot clip video to 0 or fewer seconds "
-                    f"({start_spec!r} to {end_spec!r})"
-                )
+        if end is not None and end - start <= 0:
+            raise ValueError(
+                "Cannot clip video to 0 or fewer seconds "
+                f"({start_spec!r} to {end_spec!r})"
+            )
         self._clip = (start, end)
 
     def snapshot(self, time_spec):

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -96,7 +96,7 @@ def youtube_url_to_id(url_str, url, query):
 
 
 # URLs like http://youtu.be/lalOy8Mbfdc
-def youtu_be_url_to_id(url_str, url, query):
+def youtu_be_url_to_id(url_str, url, _query):
     """Get YouTube video ID, e.g. lalOy8Mbfdc, from a youtu.be URL."""
     try:
         path = url.path.split("/")

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -8,7 +8,6 @@ import re
 import shlex
 from dataclasses import dataclass
 from multiprocessing import cpu_count
-from os.path import getmtime
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
@@ -141,7 +140,7 @@ class Video:
         self,
         url,
         options,
-        working_dir=Path("."),
+        working_dir=Path(),
         logger=LOGGER,
     ):
         self.url = url
@@ -267,7 +266,10 @@ class Video:
                 return get_key_path(self._raw_metadata, key_path)
 
             metadata_cache_path = self.raw_metadata_cache_path()
-            if getmtime(metadata_cache_path) >= getmtime(self.raw_video()):
+            if (
+                metadata_cache_path.stat().st_mtime
+                >= self.raw_video().stat().st_mtime
+            ):
                 # Metadata isn’t older than raw video.
                 with metadata_cache_path.open("r", encoding="utf_8") as file:
                     self._raw_metadata = json.load(file)


### PR DESCRIPTION
- **Lints: enable LOG and use `logging.WARNING`.**
  

- **Lints: enable ARG and fix unused function arguments.**
  

- **Lints: enable BLE and catch more specific exceptions.**
  

- **Lints: enable C90 and ignore it for certain functions.**
  

- **Lints: enable FBT and force boolean arguments to be keyword.**
  

- **Lints: Document that I don’t like CPY.**
  

- **Lints: Enable G, but disably G004 (f-strings in logging).**
  

- **Lints: Document ANN (type annotations) as a possible FIXME.**
  

- **Lints: Enable FLY and switch `join` to f-string.**
  

- **Lints: Enable PT rules, fix, and document ignores.**
  

- **In fields, rename base_path argument to base_url.**
  

- **Lints: Enable PTH rules and use `pathlib` where possible.**
  

- **Clean up `atomic_open()`: require a `Path` and keyword arguments.**
  

- **Lints: Enable SIM rules and fix failures.**
  