### PR TITLE
Build: be explicit about what to include in package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,13 @@ path = "yanki/__version__.py"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/REFERENCE.adoc",
+  "/test-decks",
+  "/tests",
+  "/uv.lock",
+  "/web-files",
+  "/yanki",
+]


### PR DESCRIPTION
This specifically does not include the asl directory.
