### PR TITLE
Fix README on PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ licenses. You may choose to use either.
   * [Apache License, Version 2.0](LICENSE-APACHE)
   * [MIT license](LICENSE-MIT)
 
+<!-- GitHub only -->
 Files in the `asl` directory are not licensed for redistribution. Copyright is
 somewhat unclear, and at least some of the material is owned by [Dr. William
 Vicars][LP].
+<!-- /GitHub only -->
 
 [Anki]: https://apps.ankiweb.net
 [yt-dlp]: https://github.com/yt-dlp/yt-dlp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,8 @@
 [project]
 name = "yanki"
-dynamic = ["version"]
+dynamic = ["readme", "version"]
 description = "Build Anki decks from text files containing YouTube URLs."
 authors = [{name = "Daniel Parks", email = "oss-yanki@demonhorse.org"}]
-readme = "README.md"
 requires-python = ">= 3.11"
 license = "MIT OR Apache-2.0"
 license-files = ["LICENSE-*"]
@@ -99,7 +98,7 @@ packages = ["yanki"]
 path = "yanki/__version__.py"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-fancy-pypi-readme"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
@@ -111,3 +110,22 @@ include = [
   "/web-files",
   "/yanki",
 ]
+
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+fragments = [{path = "README.md"}]
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+# Remove GitHub only sections from README.md.
+pattern = '(?s)<!-- GitHub only -->.+<!-- /GitHub only -->'
+replacement = ''
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+# Replace GitHub-specific [!TIP] syntax.
+pattern = '\[!TIP\]'
+replacement = '### 💡 Tip'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+# Make links to package files absolute GitHub links.
+pattern = '(?m)^(\[.+?\]):\s*((?!\w+:)\S+)'
+replacement = '\1: https://github.com/danielparks/yanki/blob/v$HFPR_VERSION/\2'


### PR DESCRIPTION
  * Fix relative links, e.g. to `REFERENCE.adoc`.
  * Remove bit about `asl` directory that doesn’t exist in package.
  * Replace `[!TIP]` with `### 💡 Tip`.

Fixes: #395
