### PR TITLE
Experimental `trim: auto` support

### DIFF
--- a/yanki/anki.py
+++ b/yanki/anki.py
@@ -139,7 +139,9 @@ class Note:
 
         clip = self.spec.clip_or_trim()
         if clip is not None:
-            if len(clip) == 1:
+            if clip == "auto":
+                video.clip_auto()
+            elif len(clip) == 1:
                 video.snapshot(clip[0])
             elif len(clip) == 2:
                 video.clip(clip[0], clip[1])
@@ -189,6 +191,7 @@ EXTRA_FINAL_NOTE_VARIABLES = frozenset(
         "media_paths",
         "video_parameters",
         "auto_crop",
+        "auto_trim",
     ]
 )
 
@@ -242,6 +245,9 @@ class FinalNote:
             "media_paths": " ".join(self.media_paths()),
             "auto_crop": " / ".join(
                 [str(media.cropdetect()) for media in self.media()]
+            ),
+            "auto_trim": " / ".join(
+                [str(media.auto_trim()) for media in self.media()]
             ),
             "video_parameters": " / ".join(
                 [" ".join(media.parameters_list()) for media in self.media()]

--- a/yanki/parser/config.py
+++ b/yanki/parser/config.py
@@ -59,7 +59,7 @@ class NoteConfig:
     overlay_text: str = ""
     tags: set[str] = field(default_factory=set)
     slow: tuple[str, str | None, float] | None = None
-    trim: tuple[str, str] | None = None
+    trim: tuple[str, str] | str | None = None
     audio: str = "include"
     video: str = "include"
     note_id: str = "{deck_id} {url} {clip}"
@@ -144,6 +144,8 @@ class NoteConfig:
     def set_trim(self, trim):
         if trim in {"", "none"}:
             self.trim = None
+        elif trim == "auto":
+            self.trim = "auto"
         else:
             clip = [part.strip() for part in trim.split("-")]
             if len(clip) != 2:
@@ -195,6 +197,8 @@ class NoteConfig:
     def trim_spec(self):
         if self.trim is None:
             return ""
+        if self.trim == "auto":
+            return "auto"
 
         return "-".join(self.trim)
 

--- a/yanki/parser/model.py
+++ b/yanki/parser/model.py
@@ -47,10 +47,14 @@ class NoteSpec:
         return self._parse_clip()[0]
 
     def clip_or_trim(self):
+        clip = self.clip()
         if self.config.trim is None:
-            return self.clip()  # Might be None, but that’s fine
-        if self.clip() is None:
+            return clip  # Might be None, but that’s fine
+        if clip is None:
             return self.config.trim
+        if self.config.trim == "auto":
+            # clip overrides trim: auto, since that’s the default.
+            return clip
         self.error(
             f"Clip ({self.provisional_clip_spec()!r}) is incompatible with "
             "'trim:'."


### PR DESCRIPTION
This adds `scdet` filter data to more_info when the video isn’t clipped.
It does not change the default for `trim:`.
