### PR TITLE
Improvements to running `ffprobe`

### DIFF
--- a/yanki/video.py
+++ b/yanki/video.py
@@ -264,12 +264,11 @@ class Video:
     # This will refresh metadata once if it doesn’t find the passed path the
     # first time.
     def raw_metadata(self, *key_path):
-        try:
-            # FIXME? Track if ffprobe was already run and don’t run it again.
-            if self._raw_metadata:
-                return get_key_path(self._raw_metadata, key_path)
+        if self._raw_metadata:
+            return get_key_path(self._raw_metadata, key_path)
 
-            metadata_cache_path = self.raw_metadata_cache_path()
+        metadata_cache_path = self.raw_metadata_cache_path()
+        try:
             if (
                 metadata_cache_path.stat().st_mtime
                 >= self.raw_video().stat().st_mtime


### PR DESCRIPTION
- **`Video`: Don’t run `ffprobe` more than once**
  Previously, if part of the `ffprobe` results were missing it would try
  to run `ffprobe` again each time missing data was requested. This limits
  it to running `ffprobe` once for each video.
  
  I don’t think this was a real problem, but it was trivial to fix.
  

- **`Video`: Don’t check metadata `mtime`**
  Previously we refreshed the metadata (`ffprobe` results) if it was older
  than the raw video. This would interfere with touching files in the
  cache to track what is actually being used, so now we no longer check
  the `mtime`.
  
  We don’t have a re-download option, but if we did it would need to
  remove metadata as well as a few other files.
  