### PR TITLE
Add trivial `Cache` class to manage cache

### DIFF
--- a/tests/filter_test.py
+++ b/tests/filter_test.py
@@ -57,26 +57,26 @@ def test_multiple_exclude():
     assert filter_deck_tags(include=["e"], exclude=["abc", "bcd"]) == "E"
 
 
-def test_read_decks_sorted(deck_1_path, deck_2_path, cache_path):
+def test_read_decks_sorted(deck_1_path, deck_2_path):
     decks = DeckSource(
         files=[
             deck_2_path.open("r", encoding="utf_8"),
             deck_1_path.open("r", encoding="utf_8"),
         ]
-    ).read_sorted(VideoOptions(cache_path))
+    ).read_sorted(VideoOptions())
 
     assert len(decks) == 2
     assert decks[0].title() == "Test::Reference deck"
     assert decks[1].title() == "Test::Reference deck::2"
 
 
-def test_read_final_decks_sorted(deck_1_path, deck_2_path, cache_path):
+def test_read_final_decks_sorted(deck_1_path, deck_2_path):
     decks = DeckSource(
         files=[
             deck_2_path.open("r", encoding="utf_8"),
             deck_1_path.open("r", encoding="utf_8"),
         ]
-    ).read_final_sorted(VideoOptions(cache_path))
+    ).read_final_sorted(VideoOptions())
 
     assert len(decks) == 2
     assert decks[0].title == "Test::Reference deck"

--- a/tests/html_test.py
+++ b/tests/html_test.py
@@ -6,15 +6,16 @@ from yanki.html_out import write_html
 from yanki.video import VideoOptions
 
 
-def test_two_decks(cache_path, deck_1_path, deck_2_path, output_path):
+def test_two_decks(deck_1_path, deck_2_path, output_path):
+    options = VideoOptions()
     files = [
         path.open("r", encoding="utf_8") for path in [deck_1_path, deck_2_path]
     ]
 
     write_html(
         output_path,
-        cache_path,
-        DeckSource(files=files).read_final_sorted(VideoOptions(cache_path)),
+        options.cache.path,
+        DeckSource(files=files).read_final_sorted(options),
         flashcards=False,
     )
 

--- a/tests/note_test.py
+++ b/tests/note_test.py
@@ -15,18 +15,18 @@ def example_note_spec():
     )
 
 
-def example_note(cache_path):
-    return Note(example_note_spec(), VideoOptions(cache_path))
+def example_note():
+    return Note(example_note_spec(), VideoOptions())
 
 
 def test_note_spec_variables():
     assert set(example_note_spec().variables().keys()) == NOTE_VARIABLES
 
 
-def test_note_variables(cache_path):
-    assert set(example_note(cache_path).variables().keys()) == NOTE_VARIABLES
+def test_note_variables():
+    assert set(example_note().variables().keys()) == NOTE_VARIABLES
 
 
-def test_final_note_variables(cache_path):
-    note = asyncio.run(example_note(cache_path).finalize_async(deck_id=1))
+def test_final_note_variables():
+    note = asyncio.run(example_note().finalize_async(deck_id=1))
     assert set(note.variables().keys()) == FINAL_NOTE_VARIABLES

--- a/tests/test-decks_test.py
+++ b/tests/test-decks_test.py
@@ -19,13 +19,12 @@ def read_first_line(path: Path):
 
 
 @pytest.mark.parametrize("path", find_deck_files("test-decks/errors"))
-def test_deck_error(path, cache_path):
-    options = VideoOptions(cache_path=cache_path)
+def test_deck_error(path):
     with (
         path.open("r", encoding="utf_8") as file,
         pytest.raises(ExceptionGroup) as error_info,
     ):
-        DeckSource(files=[file]).read_final(options)
+        DeckSource(files=[file]).read_final(VideoOptions())
 
     [error] = list(find_errors(error_info.value))
 
@@ -36,8 +35,7 @@ def test_deck_error(path, cache_path):
 
 
 @pytest.mark.parametrize("path", find_deck_files("test-decks/good"))
-def test_deck_success(path, cache_path):
-    options = VideoOptions(cache_path=cache_path)
+def test_deck_success(path):
     with path.open("r", encoding="utf_8") as file:
-        [deck] = DeckSource(files=[file]).read_final(options)
+        [deck] = DeckSource(files=[file]).read_final(VideoOptions())
     assert len(deck.notes()) >= 1

--- a/tests/video_parameters_test.py
+++ b/tests/video_parameters_test.py
@@ -3,18 +3,15 @@ import pytest
 from yanki.video import Video, VideoOptions
 
 
-def get_video(tmp_path):
-    cache_path = tmp_path / "cache"
-    cache_path.mkdir(parents=True, exist_ok=True)
-
+def get_video():
     return Video(
         "file://./test-decks/good/media/stopwatch.mp4",
-        options=VideoOptions(cache_path=cache_path),
+        options=VideoOptions(),
     )
 
 
-def test_time_parse(tmp_path):  # noqa: PLR0915 (too many statements)
-    video = get_video(tmp_path)
+def test_time_parse():  # noqa: PLR0915 (too many statements)
+    video = get_video()
 
     assert video.get_fps() == 60
 

--- a/yanki/cache.py
+++ b/yanki/cache.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+CACHEDIR_TAG_CONTENT = """Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag created by Yanki.
+# For information about cache directory tags, see:
+#	https://bford.info/cachedir/
+#
+# For information about yanki, see:
+#   https://github.com/danielparks/Yanki
+"""
+
+
+class Cache:
+    """Trivial class to manage a cache directory."""
+
+    def __init__(self, path: Path | None = None):
+        """Set up the cache directory."""
+        self.path = path
+        if self.path is None:
+            self.temporary_directory = TemporaryDirectory()
+            self.path = Path(self.temporary_directory.name)
+        self.ensure()
+
+    def ensure(self):
+        """Make sure cache is set up.
+
+        Called by __init__().
+        """
+        self.path.mkdir(parents=True, exist_ok=True)
+        (self.path / "CACHEDIR.TAG").write_text(
+            CACHEDIR_TAG_CONTENT, encoding="ascii"
+        )

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -7,7 +7,7 @@ import math
 import re
 import shlex
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from multiprocessing import cpu_count
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -15,6 +15,7 @@ from urllib.parse import parse_qs, urlparse
 import ffmpeg
 import yt_dlp
 
+from yanki.cache import Cache
 from yanki.errors import ExpectedError
 from yanki.utils import (
     NotFileURLError,
@@ -63,11 +64,11 @@ class FFmpegError(RuntimeError):
         self.exit_code = exit_code
 
 
-@dataclass
+@dataclass(kw_only=True)
 class VideoOptions:
     """Options for processing videos."""
 
-    cache_path: Path
+    cache: Cache = field(default_factory=Cache)
     progress: bool = False
     reprocess: bool = False
     concurrency: int = cpu_count()
@@ -177,7 +178,7 @@ class Video:
         self._cached_parameters = None
 
     def cached(self, filename):
-        return self.options.cache_path / filename
+        return self.options.cache.path / filename
 
     def info_cache_path(self):
         return self.cached(f"info_{self.id}.json")


### PR DESCRIPTION
By default it sets up a `TemporaryDirectory` to hold the cache.
`VideoOptions` uses this by default, which simplifies writing tests.
