### PR TITLE
Tests: log actual exceptions caught

### DIFF
--- a/tests/syntax_test.py
+++ b/tests/syntax_test.py
@@ -10,6 +10,7 @@ from yanki.utils import add_trace_logging
 
 add_trace_logging()
 logging.getLogger("yanki.parser").setLevel(logging.TRACE)
+LOGGER = logging.getLogger(__name__)
 
 
 def parse_maybe_deck(contents, name="-"):
@@ -277,4 +278,5 @@ def test_note_parametrized(note_lines, parsed_text):
 def test_errors_parametrized(deck, message):
     with pytest.raises(DeckSyntaxError) as error_info:
         parse_deck(deck)
+    LOGGER.info("Caught exception", exc_info=error_info.value)
     assert str(error_info.value) == message

--- a/tests/test-decks_test.py
+++ b/tests/test-decks_test.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import pytest
@@ -5,6 +6,8 @@ import pytest
 from yanki.cli.decks import DeckSource
 from yanki.utils import find_errors
 from yanki.video import VideoOptions
+
+LOGGER = logging.getLogger(__name__)
 
 
 def find_deck_files(base_path):
@@ -27,6 +30,7 @@ def test_deck_error(path):
         DeckSource(files=[file]).read_final(VideoOptions())
 
     [error] = list(find_errors(error_info.value))
+    LOGGER.info("Caught exception", exc_info=error)
 
     first_line = read_first_line(path)
     assert first_line[0:2] == "# "

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,8 +1,11 @@
+import logging
 from pathlib import Path
 
 import pytest
 
 from yanki.utils import NotFileURLError, atomic_open, file_url_to_path
+
+LOGGER = logging.getLogger(__name__)
 
 
 def test_atomic_open(tmp_path):
@@ -34,6 +37,7 @@ def test_atomic_open_error(tmp_path):
             file.write("Second write\n")
             file.close()
             raise RuntimeError("boo")
+    LOGGER.info("Caught exception", exc_info=error_info.value)
     assert error_info.match("boo")
 
     assert path.read_text() == "First write\n"
@@ -49,6 +53,7 @@ def test_atomic_open_deleted(tmp_path):
         with atomic_open(path) as file:
             Path(file.name).unlink()
             file.write("First write\n")
+    LOGGER.info("Caught exception", exc_info=error_info.value)
     assert error_info.match("No such file or directory")
 
     assert not path.exists()

--- a/tests/video_parameters_test.py
+++ b/tests/video_parameters_test.py
@@ -1,6 +1,10 @@
+import logging
+
 import pytest
 
 from yanki.video import Video, VideoOptions
+
+LOGGER = logging.getLogger(__name__)
 
 
 def get_video():
@@ -36,6 +40,7 @@ def test_time_parse():  # noqa: PLR0915 (too many statements)
 
     with pytest.raises(ValueError) as error_info:
         video.time_to_seconds("2ks")
+    LOGGER.info("Caught exception", exc_info=error_info.value)
     assert error_info.match("could not convert string to float")
 
     assert round(video.time_to_seconds("0:45.6"), 9) == 45.6
@@ -61,14 +66,17 @@ def test_time_parse():  # noqa: PLR0915 (too many statements)
 
     with pytest.raises(ValueError) as error_info:
         video.time_to_seconds(":2")
+    LOGGER.info("Caught exception", exc_info=error_info.value)
     assert error_info.match("could not convert string to float")
 
     with pytest.raises(ValueError) as error_info:
         video.time_to_seconds("2:")
+    LOGGER.info("Caught exception", exc_info=error_info.value)
     assert error_info.match("could not convert string to float")
 
     with pytest.raises(ValueError) as error_info:
         video.time_to_seconds("af:2")
+    LOGGER.info("Caught exception", exc_info=error_info.value)
     assert error_info.match("could not convert string to float")
 
     # FIXME? Should probably be error
@@ -85,8 +93,10 @@ def test_time_parse():  # noqa: PLR0915 (too many statements)
 
     with pytest.raises(ValueError) as error_info:
         video.time_to_seconds("2fF")
+    LOGGER.info("Caught exception", exc_info=error_info.value)
     assert error_info.match("invalid literal")
 
     with pytest.raises(ValueError) as error_info:
         video.time_to_seconds("2F0")
+    LOGGER.info("Caught exception", exc_info=error_info.value)
     assert error_info.match("could not convert string to float")


### PR DESCRIPTION
When a test expects one exception but catches another, it’s useful to
see the traceback for the caught exception. This logs the full exception
caught before checking that it’s correct.
