### PR TITLE
Video: use in-memory info for download

### DIFF
--- a/yanki/video.py
+++ b/yanki/video.py
@@ -585,10 +585,8 @@ class Video:
         self.logger.info(f"downloading raw video to {path}")
 
         with self._yt_dlp(outtmpl={"default": str(path)}) as ydl:
-            # FIXME why not use the in-memory info?
-            if error := ydl.download_with_info_file(self.info_cache_path()):
-                # FIXME??!
-                raise RuntimeError(error)
+            # Returns “resolved” info. Not useful to us.
+            ydl.process_ie_result(self.info(), download=True)
 
         return path
 


### PR DESCRIPTION
Previously this had to reload the info from a JSON file on disk. It
likely would have hit the file system cache and made very little
performance difference, but this seems cleaner, even if the API used is
poorly documented.
