### PR TITLE
`Video`: miscellaneous logging improvements

### DIFF
--- a/yanki/video.py
+++ b/yanki/video.py
@@ -249,13 +249,19 @@ class Video:
         return self.info()["title"]
 
     def load_raw_metadata(self):
-        self.logger.debug(f"load raw metadata: {self.raw_video()}")
+        self.logger.trace(f"start ffprobe on {self.raw_video()}")
+        time_started = time.perf_counter()
         try:
             self._raw_metadata = ffmpeg.probe(self.raw_video())
         except ffmpeg.Error as error:
             raise FFmpegError(
                 command="ffprobe", stdout=error.stdout, stderr=error.stderr
             ) from error
+
+        elapsed = time_started - time.perf_counter()
+        self.logger.debug(
+            f"raw metadata loaded from {self.raw_video()} in {elapsed:,.3f}s"
+        )
 
         with atomic_open(self.raw_metadata_cache_path()) as file:
             json.dump(self._raw_metadata, file)

--- a/yanki/video.py
+++ b/yanki/video.py
@@ -791,7 +791,7 @@ class Video:
             if waited < 0.001:
                 waited = 0.0
             self.logger.trace(
-                f"Start run (waited {waited:0.3}s) {shlex.join(command)}"
+                f"Start run (waited {waited:,.3f}s) {shlex.join(command)}"
             )
             process = await asyncio.create_subprocess_exec(
                 *command,
@@ -804,8 +804,8 @@ class Video:
 
         run_time = time.perf_counter() - time_started
         self.logger.debug(
-            f"Finished run (in {run_time:0.3}s, returned {process.returncode}) "
-            f"{shlex.join(command)}"
+            f"Finished run (in {run_time:,.3f}s, returned {process.returncode})"
+            f" {shlex.join(command)}"
         )
 
         if process.returncode:


### PR DESCRIPTION
- **Video: log elapsed time running `ffprobe`.**
  

- **Video: log elapsed times in fixed point format with commas.**
  