### PR TITLE
Tests: fix `cache_path` fixture scope

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,12 +25,12 @@ def bin_path(tmp_path_factory):
     return path
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def output_path(tmp_path_factory):
     return tmp_path_factory.mktemp("output")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def cache_path(tmp_path_factory):
     return tmp_path_factory.mktemp("cache")
 


### PR DESCRIPTION
Previously the `cache_path` and `output_path` fixtures were scoped to
the session. This changes them to the default scope, which means they
will be recreated for each test.
