### PR TITLE
Fix README and add test for README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,10 @@ Usage: yanki [OPTIONS] COMMAND [ARGS]...
 Options:
   -v, --verbose                 Be more verbose. May be passed up to 3 times.
   --cache DIRECTORY             Path to cache for downloads and media files.
-                                [env var: YANKI_CACHE; default:
-                                /Users/daniel/.cache/yanki]
+                                [default: $YANKI_CACHE or ~/.cache/yanki]
   --reprocess / --no-reprocess  Force reprocessing videos.
-  -j, --concurrency INTEGER     Number of ffmpeg process to run at once.  [env
-                                var: YANKI_CONCURRENCY; default: 8]
+  -j, --concurrency INTEGER     Number of ffmpeg process to run at once.
+                                [default: $YANKI_CONCURRENCY or 4]
   --version                     Show the version and exit.
   --help                        Show this message and exit.
 
@@ -91,6 +90,7 @@ Commands:
   list-notes             List notes in deck files.
   open-videos            Download, process, and open video URLs.
   open-videos-from-file  Download videos listed in a file and open them.
+  serve-flashcards       Serve HTML flashcards localhost:8000.
   serve-http             Serve HTML summary of deck on localhost:8000.
   to-html                Generate HTML version of decks.
   to-json                Generate JSON version of decks.

--- a/tests/package_test.py
+++ b/tests/package_test.py
@@ -1,0 +1,25 @@
+import re
+from multiprocessing import cpu_count
+from pathlib import Path
+
+import click
+
+from yanki.cli import cli
+
+PACKAGE_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_yanki_help():
+    readme_text = (PACKAGE_ROOT / "README.md").read_text()
+    examples = re.findall(
+        r"\n```\n❯ uvx yanki --help\n(.+?)\n```\n", readme_text, re.DOTALL
+    )
+    assert len(examples) >= 1, "Could not find --help text in README.md"
+
+    with click.Context(cli, info_name="yanki") as ctx:
+        help = cli.get_help(ctx).replace(
+            f"$YANKI_CONCURRENCY or {cpu_count()}]",
+            "$YANKI_CONCURRENCY or 4]",
+        )
+        for example in examples:
+            assert help == example, "--help does not match example in README.md"

--- a/yanki/cli/__init__.py
+++ b/yanki/cli/__init__.py
@@ -107,11 +107,10 @@ def main():  # noqa: C901 (complex)
 @click.option(
     "--cache",
     default=Path("~/.cache/yanki/").expanduser(),
-    show_default=True,
     envvar="YANKI_CACHE",
-    show_envvar=True,
     type=WritableDirectoryPath(path_type=Path),
-    help="Path to cache for downloads and media files.",
+    help="Path to cache for downloads and media files. [default: $YANKI_CACHE "
+    "or ~/.cache/yanki]",
 )
 @click.option(
     "--reprocess/--no-reprocess",
@@ -121,11 +120,10 @@ def main():  # noqa: C901 (complex)
     "-j",
     "--concurrency",
     default=cpu_count(),
-    show_default=True,
     envvar="YANKI_CONCURRENCY",
-    show_envvar=True,
     type=click.INT,
-    help="Number of ffmpeg process to run at once.",
+    help="Number of ffmpeg process to run at once. [default: $YANKI_CONCURRENCY"
+    f" or {cpu_count()}]",
 )
 @click.version_option(__version__)
 @click.pass_context


### PR DESCRIPTION
  * Add a test checking that `yanki --help` output matches any examples
    in README.md.
  * Update `yanki --help` output to be predictable regardless of
    environment, i.e. displaying certain dynamic defaults statically.
  * Update README.md to match current `yanki --help` output.
