### PR TITLE
Flashcard UI: don’t require unsafe-inline JS

### DIFF
--- a/web-files/static/flashcards.js
+++ b/web-files/static/flashcards.js
@@ -337,7 +337,7 @@ window.addEventListener("load", (event) => {
     });
 
   var directory = document.querySelector("#directory > main > ol");
-  directory.append(tree_to_li(decks_tree));
+  directory.append(tree_to_li(JSON.parse(get_id("decks-json").innerText)));
 
   var title = get_id("title");
 

--- a/web-files/templates/flashcards.html
+++ b/web-files/templates/flashcards.html
@@ -5,8 +5,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="static/flashcards.css" />
-    <script>
-      const decks_tree = { DECKS };
+    <script id="decks-json" type="application/json">
+      { DECKS }
     </script>
     <script src="static/flashcards.js" async></script>
   </head>


### PR DESCRIPTION
Previously this used inline JavaScript (`<script>...</script>`) to load
the deck tree JSON, which requires the `'unsafe-inline` setting in the
Content Security Policy header.

This switches to embedding the JSON directly in the `<script>` element
and using `JSON.parse()` to load it. This no longer requires
`'unsafe-inline'`.
