### PR TITLE
Flashcard UI: replace old deck files, and normalize names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "click >=8.1.8,<9.0",
     "mistletoe>=1.4.0",
     "pytest-asyncio>=1.1.0",
+    "unidecode>=1.4.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -340,6 +340,15 @@ wheels = [
 ]
 
 [[package]]
+name = "unidecode"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/7d/a8a765761bbc0c836e397a2e48d498305a865b70a8600fd7a942e85dcf63/Unidecode-1.4.0.tar.gz", hash = "sha256:ce35985008338b676573023acc382d62c264f307c8f7963733405add37ea2b23", size = 200149, upload-time = "2025-04-24T08:45:03.798Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/b7/559f59d57d18b44c6d1250d2eeaa676e028b9c527431f5d0736478a73ba1/Unidecode-1.4.0-py3-none-any.whl", hash = "sha256:c3c7606c27503ad8d501270406e345ddb480a7b5f38827eafe4fa82a137f0021", size = 235837, upload-time = "2025-04-24T08:45:01.609Z" },
+]
+
+[[package]]
 name = "virtualenv"
 version = "20.32.0"
 source = { registry = "https://pypi.org/simple" }
@@ -364,6 +373,7 @@ dependencies = [
     { name = "genanki" },
     { name = "mistletoe" },
     { name = "pytest-asyncio" },
+    { name = "unidecode" },
     { name = "yt-dlp" },
 ]
 
@@ -385,6 +395,7 @@ requires-dist = [
     { name = "genanki", specifier = ">=0.13.1,<0.14" },
     { name = "mistletoe", specifier = ">=1.4.0" },
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
+    { name = "unidecode", specifier = ">=1.4.0" },
     { name = "yt-dlp", specifier = ">=2024.11.4" },
 ]
 

--- a/yanki/utils.py
+++ b/yanki/utils.py
@@ -15,6 +15,8 @@ from functools import partial, partialmethod
 from pathlib import Path
 from urllib.parse import urlparse
 
+from unidecode import unidecode
+
 from yanki.errors import ExpectedError
 
 FS_ILLEGAL_CHARS = frozenset('/"[]:')
@@ -269,8 +271,8 @@ URL_UNFRIENDLY_RE = re.compile(r'[\|"\[\]:/ _]+')
 
 
 def url_friendly_name(name: str):
-    """Replace runs of URL-unfriendly characters with "_".
+    """Convert to ASCII; replace runs of URL-unfriendly characters with a"_".
 
     This is not exhaustive.
     """
-    return URL_UNFRIENDLY_RE.sub("_", name)
+    return URL_UNFRIENDLY_RE.sub("_", unidecode(name))

--- a/yanki/web/ui.py
+++ b/yanki/web/ui.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import shutil
 from collections.abc import Callable, Iterable
 from pathlib import Path
 
@@ -36,7 +37,11 @@ def save_flashcard_html_to(
     media_dir.mkdir(parents=True, exist_ok=True)
 
     deck_dir = root / "decks"
-    deck_dir.mkdir(exist_ok=True)
+    if deck_dir.exists():
+        # The deck JSON files are created with create_unique_file, which will
+        # never replace and existing file. So, we have to clear them out first.
+        shutil.rmtree(deck_dir)
+    deck_dir.mkdir()
 
     install_method(web_files / "static", root)
 


### PR DESCRIPTION
Previously, saving flashcards to a directory would only create new deck
JSON files. This switches to clearing out the old deck JSON files first.

This also swaps Unicode characters in deck JSON file names with the
closest ASCII characters, when possible.
