### PR TITLE
Web UI: fix viewer to not extend off edge of page

### DIFF
--- a/web-files/static/flashcards.css
+++ b/web-files/static/flashcards.css
@@ -99,7 +99,7 @@ button:disabled:hover {
   flex: 1;
   display: flex;
   flex-direction: column;
-  min-width: 100dvw;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -257,7 +257,6 @@ button#next-button:hover {
   margin: 0 auto;
   min-height: calc(100dvh - 70px - 67px - 2.5rlh);
   width: 600px;
-  min-width: 100dvw;
   text-align: center;
 
   /* Flash card to make it clear that it’s new. */


### PR DESCRIPTION
The `min-width` was set to the width of the window even though the
viewer sometimes has the directory sidebar next to it. Without the
`min-width` property the viewer’s minimum width is the width of its
contents, so it’s required to be present to shrink the title below the
length of its text.

There was also a `min-width` property on the cards, but it does not seem
to be necessary.
