### PR TITLE
Web UI: shrink cards when window resizes

### DIFF
--- a/web-files/static/flashcards.css
+++ b/web-files/static/flashcards.css
@@ -256,7 +256,7 @@ button#next-button:hover {
   position: relative;
   margin: 0 auto;
   min-height: calc(100dvh - 70px - 67px - 2.5rlh);
-  width: 600px;
+  max-width: 600px;
   text-align: center;
 
   /* Flash card to make it clear that it’s new. */


### PR DESCRIPTION
The card were not shrinking when the window shrunk and the sidebar was
present. This allows them to shrink, but ensures they never get too wide.
