### PR TITLE
Miscellaneous pre-commit-hooks changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=1024"]
       - id: check-case-conflict
       - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
       - id: check-json
       - id: check-symlinks
       - id: check-toml
@@ -15,6 +16,7 @@ repos:
       - id: check-merge-conflict
       - id: detect-private-key
       - id: mixed-line-ending
+        args: ["--fix=no"]
       - id: name-tests-test
       - id: no-commit-to-branch
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
  * Bump pre-commit-hooks to v6.0.0.
  * Add `check-shebang-scripts-are-executable`.
  * Configure `mixed-line-ending` to only check, not fix.
